### PR TITLE
reset the __worldTransformInvalid flag on __update

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -626,7 +626,6 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 
 				current = list[i];
 				current.__update (true, false);
-				current.__worldTransformInvalid = false;
 
 			}
 				
@@ -910,6 +909,8 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 			
 		//}
 		
+		__worldTransformInvalid = false;
+
 		if (maskGraphics != null) {
 			
 			__updateMask (maskGraphics);


### PR DESCRIPTION
this can e.g. save some milliseconds in `__hitTest` when dragging stuff, because before `__update` would update all the transforms without resetting the flag, so `__getWorldTransform` would call `__update` again