### PR TITLE
reduce allocations in DisplayObject.getBounds, do less work when targetCoordinateSpace == this

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -267,18 +267,23 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	
 	public function getBounds (targetCoordinateSpace:DisplayObject):Rectangle {
 		
-		var matrix;
-		var usingTemp = false;
+		var matrix = Matrix.__pool.get ();
 		
-		if (targetCoordinateSpace != null) {
+		if (targetCoordinateSpace != null && targetCoordinateSpace != this) {
 			
-			matrix = __getWorldTransform ().clone ();
-			matrix.concat (targetCoordinateSpace.__getWorldTransform ().clone ().invert ());
+			matrix.copyFrom (__getWorldTransform ());
+			
+			var targetMatrix = Matrix.__pool.get ();
+			
+			targetMatrix.copyFrom (targetCoordinateSpace.__getWorldTransform ());
+			targetMatrix.invert ();
+			
+			matrix.concat (targetMatrix);
+
+			Matrix.__pool.release (targetMatrix);
 			
 		} else {
 			
-			usingTemp = true;
-			matrix = Matrix.__pool.get ();
 			matrix.identity ();
 			
 		}
@@ -286,11 +291,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		var bounds = new Rectangle ();
 		__getBounds (bounds, matrix);
 		
-		if (usingTemp) {
-			
-			Matrix.__pool.release (matrix);
-			
-		}
+		Matrix.__pool.release (matrix);
 		
 		return bounds;
 		


### PR DESCRIPTION
subj. I discussed this with Joshua yesterday, this is an easy improvement that should reduce GC load a bit when using getBounds, which is often called when we calculate stuff on UI initialization