### PR TITLE
store VAOs on the BitmapData, not the DisplayObject

### DIFF
--- a/src/openfl/_internal/renderer/opengl/GLVAORenderHelper.hx
+++ b/src/openfl/_internal/renderer/opengl/GLVAORenderHelper.hx
@@ -51,14 +51,14 @@ class GLVAORenderHelper {
 			renderSession.shaderManager.updateShader (shader);
 			shader.__skipEnableVertexAttribArray = false;
 			
-			var hasVAO: Bool = displayObject.__vao != null;
+			var hasVAO: Bool = bitmapData.__vao != null;
 			if (!hasVAO) {
 				
-				displayObject.__vao = vaoContext.createVertexArray ();
+				bitmapData.__vao = vaoContext.createVertexArray ();
 				
 			}
 			
-			vaoContext.bindVertexArray (displayObject.__vao);
+			vaoContext.bindVertexArray (bitmapData.__vao);
 			if (!hasVAO || bitmapData.isBufferDirty (gl, displayObject.__worldAlpha, displayObject.__worldColorTransform)) {
 				
 				__enableVertexAttribArray (gl, shader);
@@ -96,14 +96,14 @@ class GLVAORenderHelper {
 			renderSession.shaderManager.updateShader (shader);
 			shader.__skipEnableVertexAttribArray = false;
 			
-			var hasVAO: Bool = displayObject.__vaoMask != null;
+			var hasVAO: Bool = bitmapData.__vaoMask != null;
 			if (!hasVAO) {
 				
-				displayObject.__vaoMask = vaoContext.createVertexArray ();
+				bitmapData.__vaoMask = vaoContext.createVertexArray ();
 				
 			}
 			
-			vaoContext.bindVertexArray (displayObject.__vaoMask);
+			vaoContext.bindVertexArray (bitmapData.__vaoMask);
 			if (!hasVAO || bitmapData.isBufferDirty (gl, displayObject.__worldAlpha, displayObject.__worldColorTransform)) {
 				
 				gl.enableVertexAttribArray (shader.data.aPosition.index);

--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -66,6 +66,17 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 		
 	}
 	
+	private override function __cleanup (renderSession: RenderSession):Void {
+		
+		super.__cleanup (renderSession);
+		
+		if (__bitmapData != null) {
+			
+			__bitmapData.__cleanup (renderSession);
+			
+		}
+		
+	}
 	
 	private override function __enterFrame (deltaTime:Int):Void {
 		

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -12,6 +12,7 @@ import lime.graphics.cairo.Cairo;
 import lime.graphics.opengl.GLBuffer;
 import lime.graphics.opengl.GLFramebuffer;
 import lime.graphics.opengl.GLTexture;
+import lime.graphics.opengl.GLVertexArrayObject;
 import lime.graphics.opengl.GL;
 import lime.graphics.opengl.WebGLContext;
 import lime.graphics.GLRenderContext;
@@ -124,6 +125,8 @@ class BitmapData implements IBitmapDrawable {
 	private var __worldColorTransform:ColorTransform;
 	private var __worldTransform:Matrix;
 	
+	private var __vao:GLVertexArrayObject;
+	private var __vaoMask:GLVertexArrayObject;
 	
 	public function new (width:Int, height:Int, transparent:Bool = true, fillColor:UInt = 0xFFFFFFFF) {
 		
@@ -1641,6 +1644,25 @@ class BitmapData implements IBitmapDrawable {
 		}
 		
 		image.version++;
+		
+	}
+	
+	
+	function __cleanup (renderSession: RenderSession):Void {
+
+		if (__vao != null) {
+			
+			renderSession.vaoContext.deleteVertexArray (__vao);
+			__vao = null;
+			
+		}
+		
+		if (__vaoMask != null) {
+			
+			renderSession.vaoContext.deleteVertexArray (__vaoMask);
+			__vaoMask = null;
+			
+		}
 		
 	}
 	

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -128,8 +128,6 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	private var __updateDirty:Bool;
 	private var __updateTraverse:Bool;
 	private var __visible:Bool;
-	private var __vao:GLVertexArrayObject;
-	private var __vaoMask:GLVertexArrayObject;
 	private var __worldAlpha:Float;
 	private var __worldAlphaChanged:Bool;
 	private var __worldBlendMode:BlendMode;
@@ -402,20 +400,6 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 			__graphics.__cleanup ();
 			
 		}
-		
-		if (__vao != null) {
-			
-			renderSession.vaoContext.deleteVertexArray (__vao);
-			__vao = null;
-			
-		} 
-		
-		if (__vaoMask != null) {
-			
-			renderSession.vaoContext.deleteVertexArray (__vaoMask);
-			__vaoMask = null;
-			
-		} 
 		
 	}
 	


### PR DESCRIPTION
Vertex Array Object that stores the render state for drawing the bitmap should be a property of `BitmapData`, just like its texture/buffer, not the `Bitmap` display object.

This fixes a bug with setting `Bitmap.bitmapData` to an "already-used" `BitmapData` object not affecting rendering (because VAOs isn't updated).