### PR TITLE
Don't try to "sync" BitmapData's Image before uploading it as a texture.

### DIFF
--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -1147,10 +1147,6 @@ class BitmapData implements IBitmapDrawable {
 			
 		}
 		
-		#if (js && html5)
-		ImageCanvasUtil.sync (image, false);
-		#end
-		
 		if (image != null && image.version != __textureVersion) {
 			
 			var internalFormat, format;
@@ -2222,15 +2218,6 @@ class BitmapData implements IBitmapDrawable {
 		this.height = height;
 		this.rect.width = width;
 		this.rect.height = height;
-		
-	}
-	
-	
-	private function __sync ():Void {
-		
-		#if (js && html5)
-		ImageCanvasUtil.sync (image, false);
-		#end
 		
 	}
 	


### PR DESCRIPTION
This will cause it to be drawn to a freshly-created Canvas which is heavy (esp. on MS Edge) and unnecessary because texImage2D supports uploading directly from Image elements.

> PS also remove unused __sync method just so it doesn't show up when searching for ImageCanvasUtil usages :)