### PR TITLE
Filters on bitmap are still rendered after they are being removed. Ca…

### DIFF
--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -280,7 +280,7 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 	
 	private override function __updateCacheBitmap (renderSession:RenderSession, force:Bool):Bool {
 		
-		if (!__hasFilters () && __cacheBitmap == null) return false;
+		if (!__hasFilters () && renderSession.gl != null && __cacheBitmap == null) return false;
 		return super.__updateCacheBitmap (renderSession, force);
 		
 	}

--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -280,7 +280,7 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 	
 	private override function __updateCacheBitmap (renderSession:RenderSession, force:Bool):Bool {
 		
-		if (!__hasFilters ()) return false;
+		if (!__hasFilters () && __cacheBitmap == null) return false;
 		return super.__updateCacheBitmap (renderSession, force);
 		
 	}


### PR DESCRIPTION
Filters on bitmap are still rendered after they are being removed. CacheBitmap has to be cleared once filters are removed