### PR TITLE
don't render cache bitmaps smoothed when not scaled

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1177,7 +1177,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 
 			}
 			
-			__cacheBitmap.smoothing = renderSession.allowSmoothing;
+			__cacheBitmap.smoothing = false;
 			__cacheBitmap.__renderable = __renderable;
 			__cacheBitmap.__worldAlpha = __worldAlpha;
 			__cacheBitmap.__worldBlendMode = __worldBlendMode;


### PR DESCRIPTION
should fix blurry bitmaps with filters (https://jira.innogames.de/browse/FOE-49104)