### PR TITLE
Textfield autosize right and center fixed

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -1784,13 +1784,21 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 		
 		if (value != __textEngine.autoSize) {
 			
-			__dirty = true;
+			__textEngine.autoSize = value;
 			__layoutDirty = true;
+			
+			if (value == RIGHT || value == CENTER) {
+				
+				__updateLayout ();
+				
+			}
+			
+			__dirty = true;
 			__setRenderDirty ();
 			
 		}
 		
-		return __textEngine.autoSize = value;
+		return value;
 		
 	}
 	


### PR DESCRIPTION
TextField autoSize center and right property changes the position of the TextField. So the position of the TextField depends on the order on which its `x` and `autoSize` property is set. Therefore we have to update `x` position of the TextField as soon as its `autoSize` property is set to right or center. In such cases we call `__updateLayout` which does the necessary calculations an updates TextField's position base on the autoSizing. Below, there is an example of different positioning of the TextField based on the order how the properties are set.
```
// Set autoSize first
var tf: TextField = new TextField();
tf.autoSize = TextFieldAutoSize.RIGHT;
tf.x = 10;
tf.text = "Some Text";
trace(tf.x);  // -41

// Set position first
var tf: TextField = new TextField();
tf.x = 10;
tf.autoSize = TextFieldAutoSize.RIGHT;
tf.text = "Some Text";
trace(tf.x); // 55

// Set position Last
var tf: TextField = new TextField();
tf.text = "Some Text";
tf.autoSize = TextFieldAutoSize.RIGHT;
tf.x = 10;
trace(tf.x); //10

```
