### PR TITLE
fix BitmapData.draw/__draw smoothing property for HTML5

### DIFF
--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -573,11 +573,9 @@ class BitmapData implements IBitmapDrawable {
 			renderSession.blendModeManager = new CanvasBlendModeManager (renderSession);
 			renderSession.blendModeManager.setBlendMode(blendMode);
 			
-			if (!smoothing) {
-				
-				CanvasSmoothing.setEnabled(buffer.__srcContext, false);
-				
-			}
+			buffer.__srcContext.save();
+
+			CanvasSmoothing.setEnabled(buffer.__srcContext, smoothing);
 			
 			if (clipRect != null) {
 				
@@ -594,11 +592,7 @@ class BitmapData implements IBitmapDrawable {
 			Matrix.__pool.release (matrixCache);
 			source.__updateChildren (true);
 			
-			if (!smoothing) {
-				
-				CanvasSmoothing.setEnabled(buffer.__srcContext, true);
-				
-			}
+			buffer.__srcContext.restore();
 			
 			if (clipRect != null) {
 				
@@ -606,7 +600,6 @@ class BitmapData implements IBitmapDrawable {
 				
 			}
 			
-			buffer.__srcContext.setTransform (1, 0, 0, 1, 0, 0);
 			buffer.__srcImageData = null;
 			buffer.data = null;
 			
@@ -1777,11 +1770,9 @@ class BitmapData implements IBitmapDrawable {
 			renderSession.maskManager = new CanvasMaskManager (renderSession);
 			renderSession.blendModeManager = new CanvasBlendModeManager (renderSession);
 			
-			if (!smoothing) {
-				
-				CanvasSmoothing.setEnabled(buffer.__srcContext, false);
-				
-			}
+			buffer.__srcContext.save();
+			
+			CanvasSmoothing.setEnabled(buffer.__srcContext, smoothing);
 			
 			if (clipRect != null) {
 				
@@ -1812,11 +1803,7 @@ class BitmapData implements IBitmapDrawable {
 			Matrix.__pool.release (matrixCache);
 			source.__updateChildren (true);
 			
-			if (!smoothing) {
-				
-				CanvasSmoothing.setEnabled(buffer.__srcContext, true);
-				
-			}
+			buffer.__srcContext.restore();
 			
 			if (clipRect != null) {
 				
@@ -1824,7 +1811,6 @@ class BitmapData implements IBitmapDrawable {
 				
 			}
 			
-			buffer.__srcContext.setTransform (1, 0, 0, 1, 0, 0);
 			buffer.__srcImageData = null;
 			buffer.data = null;
 			


### PR DESCRIPTION
Instead of for some reason relying that the current context state always has smoothing enabled, we save the state, set the smoothing to whatever we passed as the `smoothing` argument value, and then restore the state after drawing. 

PS Also removed `setTransform` after drawing because that is also handled by the `restore` call.