### PR TITLE
add pixelSnapping support for Tilemap as well

### DIFF
--- a/src/openfl/_internal/renderer/opengl/GLTilemap.hx
+++ b/src/openfl/_internal/renderer/opengl/GLTilemap.hx
@@ -54,7 +54,7 @@ class GLTilemap {
 		
 		var shader = renderSession.shaderManager.initShader (tilemap.shader);
 		
-		var uMatrix = renderer.getMatrix (tilemap.__renderTransform);
+		var uMatrix = renderer.getMatrix (tilemap.__renderTransform, tilemap.__snapToPixel ());
 		var smoothing = (renderSession.allowSmoothing && tilemap.smoothing);
 		
 		var useColorTransform = true || !tilemap.__worldColorTransform.__isDefault ();

--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -29,7 +29,7 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 	
 	
 	public var bitmapData (get, set):BitmapData;
-	public var pixelSnapping:PixelSnapping;
+	public var pixelSnapping (get, set):PixelSnapping;
 	@:beta public var shader:Shader;
 	public var smoothing:Bool;
 	
@@ -55,14 +55,11 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 		super ();
 		
 		__bitmapData = bitmapData;
-		this.pixelSnapping = pixelSnapping;
+
+		if (pixelSnapping == null) pixelSnapping = PixelSnapping.AUTO;
+		__pixelSnapping = pixelSnapping;
+
 		this.smoothing = smoothing;
-		
-		if (pixelSnapping == null) {
-			
-			this.pixelSnapping = PixelSnapping.AUTO;
-			
-		}
 		
 	}
 	
@@ -310,17 +307,6 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 		
 	}
 	
-	
-	private inline function __snapToPixel (): Bool {
-
-		return switch pixelSnapping {
-			case NEVER: false;
-			case ALWAYS: true;
-			case AUTO: __rotation == 0 && __renderTransform.a != 0 && __renderTransform.d != 0; // only snap when not rotated or skewed
-		
-		}
-
-	}
 	
 	// Get & Set Methods
 	

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -139,6 +139,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	private var __worldVisibleChanged:Bool;
 	private var __worldTransformInvalid:Bool;
 	private var __worldZ:Int;
+	private var __pixelSnapping:PixelSnapping;
 	
 	#if (js && html5)
 	private var __canvas:CanvasElement;
@@ -1387,11 +1388,36 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	}
 	
 	
+	private inline function __snapToPixel (): Bool {
+		
+		return switch __pixelSnapping {
+			case NEVER: false;
+			case ALWAYS: true;
+			case AUTO: __rotation == 0 && __renderTransform.a != 0 && __renderTransform.d != 0; // only snap when not rotated or skewed
+		}
+		
+	}
 	
 	
 	// Get & Set Methods
 	
 	
+	inline function get_pixelSnapping() {
+		
+		return __pixelSnapping;
+		
+	}
+	
+	function set_pixelSnapping(value) {
+		
+		if (__pixelSnapping != value) {
+			__pixelSnapping = value;
+			__setRenderDirty ();
+		}
+		
+		return value;
+		
+	}
 	
 	
 	private function get_alpha ():Float {

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1391,7 +1391,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	private inline function __snapToPixel (): Bool {
 		
 		return switch __pixelSnapping {
-			case NEVER: false;
+			case null | NEVER: false;
 			case ALWAYS: true;
 			case AUTO: __rotation == 0 && __renderTransform.a != 0 && __renderTransform.d != 0; // only snap when not rotated or skewed
 		}

--- a/src/openfl/display/Tilemap.hx
+++ b/src/openfl/display/Tilemap.hx
@@ -42,6 +42,7 @@ class Tilemap extends #if !flash DisplayObject #else Bitmap implements IDisplayO
 	public var tileset (get, set):Tileset;
 	
 	#if !flash
+	public var pixelSnapping (get, set):PixelSnapping;
 	public var smoothing:Bool;
 	#end
 	
@@ -65,11 +66,15 @@ class Tilemap extends #if !flash DisplayObject #else Bitmap implements IDisplayO
 	#end
 	
 	
-	public function new (width:Int, height:Int, tileset:Tileset = null, smoothing:Bool = true) {
+	public function new (width:Int, height:Int, tileset:Tileset = null, pixelSnapping:PixelSnapping = null, smoothing:Bool = true) {
 		
 		super ();
 		
 		__tileset = tileset;
+
+		if (pixelSnapping == null) pixelSnapping = PixelSnapping.AUTO;
+		__pixelSnapping = pixelSnapping;
+
 		this.smoothing = smoothing;
 		
 		__tiles = new Vector ();
@@ -80,7 +85,6 @@ class Tilemap extends #if !flash DisplayObject #else Bitmap implements IDisplayO
 		__height = height;
 		#else
 		bitmapData = new BitmapData (width, height, true, 0);
-		this.smoothing = smoothing;
 		FlashRenderer.register (this);
 		#end
 		


### PR DESCRIPTION
We move the `__pixelSnapping` property and the `__snapToPixel` method to`DisplayObject` not to duplicate code (esp if we need another DO child with snapping support), but keeping it private and only exposing as a public get/set property in `Bitmap` and `Tilemap`. 