### PR TITLE
remove unused maskGraphics argument from __update and __updateMask method

### DIFF
--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -283,31 +283,6 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 	}
 	
 	
-	public override function __updateMask (maskGraphics:Graphics):Void {
-		
-		if (__bitmapData == null) {
-			
-			return;
-			
-		}
-		
-		maskGraphics.__commands.overrideMatrix (this.__worldTransform);
-		maskGraphics.beginFill (0);
-		maskGraphics.drawRect (0, 0, __bitmapData.width, __bitmapData.height);
-		
-		if (maskGraphics.__bounds == null) {
-			
-			maskGraphics.__bounds = new Rectangle ();
-			
-		}
-		
-		__getBounds (maskGraphics.__bounds, @:privateAccess Matrix.__identity);
-		
-		super.__updateMask (maskGraphics);
-		
-	}
-	
-	
 	// Get & Set Methods
 	
 	

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -2209,13 +2209,6 @@ class BitmapData implements IBitmapDrawable {
 	}
 	
 	
-	public function __updateMask (maskGraphics:Graphics):Void {
-		
-		
-		
-	}
-	
-	
 	public function __updateTransforms (overrideTransform:Matrix = null):Void {
 		
 		if (overrideTransform == null) {

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -966,13 +966,13 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		
 		if (__updateDirty) {
 			
-			__update (false, true, null, true);
+			__update (false, true, true);
 			
 		}
 	}
 	
 	
-	public function __update (transformOnly:Bool, updateChildren:Bool, ?maskGraphics:Graphics = null, ?resetUpdateDirty:Bool = false):Void {
+	public function __update (transformOnly:Bool, updateChildren:Bool, ?resetUpdateDirty:Bool = false):Void {
 		
 		if (resetUpdateDirty) {
 			
@@ -994,12 +994,6 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		
 		__worldTransformInvalid = false;
 
-		if (maskGraphics != null) {
-			
-			__updateMask (maskGraphics);
-			
-		}
-		
 		if (!transformOnly) {
 			
 			if (__supportDOM) {
@@ -1080,7 +1074,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		
 		if (updateChildren && mask != null) {
 			
-			mask.__update (transformOnly, true, maskGraphics, resetUpdateDirty);
+			mask.__update (transformOnly, true, resetUpdateDirty);
 			
 		}
 		
@@ -1312,28 +1306,6 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		if (__transformDirty) {
 			
 			__transformDirty = false;
-			
-		}
-		
-	}
-	
-	
-	public function __updateMask (maskGraphics:Graphics):Void {
-		
-		if (__graphics != null) {
-			
-			maskGraphics.__commands.overrideMatrix (this.__worldTransform);
-			maskGraphics.__commands.append (__graphics.__commands);
-			maskGraphics.__dirty = true;
-			maskGraphics.__visible = true;
-			
-			if (maskGraphics.__bounds == null) {
-				
-				maskGraphics.__bounds = new Rectangle();
-				
-			}
-			
-			__graphics.__getBounds (maskGraphics.__bounds, @:privateAccess Matrix.__identity);
 			
 		}
 		

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -981,7 +981,7 @@ class DisplayObjectContainer extends InteractiveObject {
 		
 		if (__updateDirty) {
 			
-			__update (false, true, null, true);
+			__update (false, true, true);
 			
 		} else if (__updateTraverse) {
 			
@@ -999,15 +999,15 @@ class DisplayObjectContainer extends InteractiveObject {
 	}
 	
 	
-	public override function __update (transformOnly:Bool, updateChildren:Bool, ?maskGraphics:Graphics = null, ?resetUpdateDirty:Bool = false):Void {
+	public override function __update (transformOnly:Bool, updateChildren:Bool, ?resetUpdateDirty:Bool = false):Void {
 		
-		super.__update (transformOnly, updateChildren, maskGraphics, resetUpdateDirty);
+		super.__update (transformOnly, updateChildren, resetUpdateDirty);
 		
 		if (updateChildren) {
 			
 			for (child in __children) {
 				
-				child.__update (transformOnly, true, maskGraphics, resetUpdateDirty);
+				child.__update (transformOnly, true, resetUpdateDirty);
 				
 			}
 			

--- a/src/openfl/display/IBitmapDrawable.hx
+++ b/src/openfl/display/IBitmapDrawable.hx
@@ -27,6 +27,4 @@ interface IBitmapDrawable {
 	private function __updateChildren (transformOnly:Bool):Void;
 	private function __updateTransforms (?overrideTransform:Matrix = null):Void;
 	
-	private function __updateMask (maskGraphics:Graphics):Void;
-	
 }

--- a/src/openfl/display/SimpleButton.hx
+++ b/src/openfl/display/SimpleButton.hx
@@ -385,21 +385,21 @@ class SimpleButton extends InteractiveObject {
 	}
 	
 	
-	public override function __update (transformOnly:Bool, updateChildren:Bool, ?maskGraphics:Graphics = null, ?resetUpdateDirty:Bool = false):Void {
+	public override function __update (transformOnly:Bool, updateChildren:Bool, ?resetUpdateDirty:Bool = false):Void {
 		
-		super.__update (transformOnly, updateChildren, maskGraphics, resetUpdateDirty);
+		super.__update (transformOnly, updateChildren, resetUpdateDirty);
 		
 		if (updateChildren) {
 			
 			if (__currentState != null) {
 				
-				__currentState.__update (transformOnly, true, maskGraphics, resetUpdateDirty);
+				__currentState.__update (transformOnly, true, resetUpdateDirty);
 				
 			}
 			
 			if (hitTestState != null && hitTestState != __currentState) {
 				
-				hitTestState.__update (transformOnly, true, maskGraphics, resetUpdateDirty);
+				hitTestState.__update (transformOnly, true, resetUpdateDirty);
 				
 			}
 			

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1982,13 +1982,13 @@ class Stage extends DisplayObjectContainer implements IModule {
 	}
 	
 	
-	public override function __update (transformOnly:Bool, updateChildren:Bool, ?maskGraphics:Graphics = null, ?resetUpdateDirty:Bool = false):Void {
+	public override function __update (transformOnly:Bool, updateChildren:Bool, ?resetUpdateDirty:Bool = false):Void {
 		
 		if (transformOnly) {
 			
 			if (__transformDirty) {
 				
-				super.__update (true, updateChildren, maskGraphics, resetUpdateDirty);
+				super.__update (true, updateChildren, resetUpdateDirty);
 				
 				if (updateChildren) {
 					
@@ -2003,7 +2003,7 @@ class Stage extends DisplayObjectContainer implements IModule {
 			
 			if (__transformDirty || __renderDirty) {
 				
-				super.__update (false, updateChildren, maskGraphics, resetUpdateDirty);
+				super.__update (false, updateChildren, resetUpdateDirty);
 				
 				if (updateChildren) {
 					
@@ -2025,7 +2025,7 @@ class Stage extends DisplayObjectContainer implements IModule {
 				// If we were dirty last time, we need at least one more
 				// update in order to clear "changed" properties
 				
-				super.__update (false, updateChildren, maskGraphics, resetUpdateDirty);
+				super.__update (false, updateChildren, resetUpdateDirty);
 				
 				if (updateChildren) {
 					


### PR DESCRIPTION
in newer OpenFL the argument is already removed, but the method is not (although it's unused), so I'm going to make an upstream PR removing the __updateMask method.