### PR TITLE
Set DisplayObject rotation range equal to flash

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1653,7 +1653,8 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		
 		if (value != __rotation) {
 			
-			__rotation = value;
+			__rotation = __normalizeAngleAS3(value);
+			
 			var radians = __rotation * (Math.PI / 180);
 			__rotationSine = Math.sin (radians);
 			__rotationCosine = Math.cos (radians);
@@ -1669,6 +1670,21 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		
 		return value;
 		
+	}
+
+
+	private inline function __normalizeAngleAS3(value:Float):Float {
+
+		var normalized: Float = value % 360;
+
+		if (normalized > 180) {
+			normalized -= 360;
+		} else if (normalized < -180) {
+			normalized += 360;
+		}
+
+		return normalized;
+
 	}
 	
 	

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1650,10 +1650,12 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	
 	
 	private function set_rotation (value:Float):Float {
-		
+
+		value = __normalizeAngle(value);
+
 		if (value != __rotation) {
 			
-			__rotation = __normalizeAngle(value);
+			__rotation = value;
 
 			var radians = __rotation * (Math.PI / 180);
 			__rotationSine = Math.sin (radians);
@@ -1673,7 +1675,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	}
 
 
-	private static inline function __normalizeAngle(value:Float):Float {
+	private static inline function __normalizeAngle (value:Float):Float {
 
 		var normalized: Float = value % 360;
 

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1651,12 +1651,11 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	
 	private function set_rotation (value:Float):Float {
 
-		value = __normalizeAngle(value);
+		value = __normalizeAngle (value);
 
 		if (value != __rotation) {
 			
 			__rotation = value;
-
 			var radians = __rotation * (Math.PI / 180);
 			__rotationSine = Math.sin (radians);
 			__rotationCosine = Math.cos (radians);

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1653,8 +1653,8 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		
 		if (value != __rotation) {
 			
-			__rotation = __normalizeAngleAS3(value);
-			
+			__rotation = __normalizeAngle(value);
+
 			var radians = __rotation * (Math.PI / 180);
 			__rotationSine = Math.sin (radians);
 			__rotationCosine = Math.cos (radians);
@@ -1673,7 +1673,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	}
 
 
-	private inline function __normalizeAngleAS3(value:Float):Float {
+	private static inline function __normalizeAngle(value:Float):Float {
 
 		var normalized: Float = value % 360;
 


### PR DESCRIPTION
In flash, display object rotation ranges from -180 to 180 degrees. In OpenFL we don't have such range at all.