### PR TITLE
Do not double smooth in GLShape

### DIFF
--- a/src/openfl/_internal/renderer/opengl/GLShape.hx
+++ b/src/openfl/_internal/renderer/opengl/GLShape.hx
@@ -59,7 +59,7 @@ class GLShape {
 				renderSession.shaderManager.setShader (shader);
 				
 				shader.data.uImage0.input = graphics.__bitmap;
-				shader.data.uImage0.smoothing = renderSession.allowSmoothing;
+				shader.data.uImage0.smoothing = false;
 				shader.data.uMatrix.value = renderer.getMatrix (graphics.__worldTransform);
 				
 				var useColorTransform = !shape.__worldColorTransform.__isDefault ();


### PR DESCRIPTION
Since smoothing is applied in Canvas renderers invoked from GLShape render method, it shouldn't be applied in GLShape rendering