### PR TITLE
support drawing to canvas from SubBitmapData

### DIFF
--- a/src/openfl/_internal/renderer/canvas/CanvasBitmap.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasBitmap.hx
@@ -19,45 +19,20 @@ class CanvasBitmap {
 		
 		var context = renderSession.context;
 		
-		if (bitmap.__bitmapData != null && bitmap.__bitmapData.__isValid && bitmap.__bitmapData.__prepareImage()) {
+		if (bitmap.__bitmapData != null && bitmap.__bitmapData.__isValid && bitmap.__bitmapData.__canBeDrawnToCanvas ()) {
 			
 			renderSession.blendModeManager.setBlendMode (bitmap.__worldBlendMode);
 			renderSession.maskManager.pushObject (bitmap, false);
-			
-			ImageCanvasUtil.convertToCanvas (bitmap.__bitmapData.image);
-			
-			context.globalAlpha = bitmap.__worldAlpha;
-			var transform = bitmap.__renderTransform;
-			var scrollRect = bitmap.__scrollRect;
-			var pixelRatio = renderSession.pixelRatio;
-			var scale = pixelRatio / bitmap.__bitmapData.__pixelRatio; // Bitmaps can have different pixelRatio than display, therefore we need to scale them properly
-			
-			if (renderSession.roundPixels || bitmap.__snapToPixel ()) {
-				
-				context.setTransform (transform.a * scale, transform.b, transform.c, transform.d * scale, Math.round (transform.tx * pixelRatio), Math.round  (transform.ty * pixelRatio));
-				
-			} else {
-				
-				context.setTransform (transform.a * scale, transform.b, transform.c, transform.d * scale, transform.tx * pixelRatio, transform.ty * pixelRatio);
-				
-			}
-			
+
 			if (!renderSession.allowSmoothing || !bitmap.smoothing) {
 				
 				CanvasSmoothing.setEnabled(context, false);
 				
 			}
 			
-			if (scrollRect == null) {
-				
-				context.drawImage (bitmap.__bitmapData.image.src, 0, 0);
-				
-			} else {
-				
-				context.drawImage (bitmap.__bitmapData.image.src, scrollRect.x, scrollRect.y, scrollRect.width, scrollRect.height, scrollRect.x, scrollRect.y, scrollRect.width, scrollRect.height);
-				
-			}
-			
+			context.globalAlpha = bitmap.__worldAlpha;
+			bitmap.__bitmapData.__drawToCanvas (context, bitmap.__renderTransform, renderSession.roundPixels || bitmap.__snapToPixel (), renderSession.pixelRatio, bitmap.__scrollRect, true);
+
 			if (!renderSession.allowSmoothing || !bitmap.smoothing) {
 				
 				CanvasSmoothing.setEnabled(context, true);

--- a/src/openfl/_internal/renderer/canvas/CanvasTilemap.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasTilemap.hx
@@ -85,11 +85,10 @@ class CanvasTilemap {
 			bitmapData = tileset.bitmapData;
 			if (bitmapData == null || !bitmapData.__canBeDrawnToCanvas()) continue;
 			
-			context.globalAlpha = tilemap.__worldAlpha * alpha;
-			
 			tileTransform = tile.matrix;
 			tileTransform.concat (transform);
 			
+			context.globalAlpha = tilemap.__worldAlpha * alpha;
 			bitmapData.__drawToCanvas (context, tileTransform, roundPixels, renderSession.pixelRatio, tileRect, false);
 			
 		}

--- a/src/openfl/_internal/renderer/canvas/CanvasTilemap.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasTilemap.hx
@@ -47,7 +47,6 @@ class CanvasTilemap {
 		}
 		
 		var defaultTileset = tilemap.__tileset;
-		var cacheBitmapData = null;
 		var source = null;
 		
 		var alpha, visible, tileset, id, tileData, bitmapData;
@@ -84,38 +83,14 @@ class CanvasTilemap {
 			}
 			
 			bitmapData = tileset.bitmapData;
-			if (bitmapData == null || !bitmapData.__prepareImage()) continue;
-			
-			if (bitmapData != cacheBitmapData) {
-				
-				if (bitmapData.image.buffer.__srcImage == null) {
-					
-					ImageCanvasUtil.convertToCanvas (bitmapData.image);
-					
-				}
-				
-				source = bitmapData.image.src;
-				cacheBitmapData = bitmapData;
-				
-			}
+			if (bitmapData == null || !bitmapData.__canBeDrawnToCanvas()) continue;
 			
 			context.globalAlpha = tilemap.__worldAlpha * alpha;
 			
 			tileTransform = tile.matrix;
 			tileTransform.concat (transform);
-			var pixelRatio = renderSession.pixelRatio;
 			
-			if (roundPixels) {
-				
-				context.setTransform (tileTransform.a * pixelRatio, tileTransform.b, tileTransform.c, tileTransform.d * pixelRatio, Math.round (tileTransform.tx * pixelRatio), Math.round (tileTransform.ty * pixelRatio));
-				
-			} else {
-				
-				context.setTransform (tileTransform.a * pixelRatio, tileTransform.b, tileTransform.c, tileTransform.d * pixelRatio, tileTransform.tx * pixelRatio, tileTransform.ty * pixelRatio);
-				
-			}
-			
-			context.drawImage (source, tileRect.x, tileRect.y, tileRect.width, tileRect.height, 0, 0, tileRect.width, tileRect.height);
+			bitmapData.__drawToCanvas (context, tileTransform, roundPixels, renderSession.pixelRatio, tileRect, false);
 			
 		}
 		


### PR DESCRIPTION
This changes `CanvasBitmap` and `CanvasTilemap` to call `BitmapData`'s own `__drawToCanvas` method instead of drawing the image directly. Apart from the copy-paste removal, this allows us to override the drawing behaviour for `SubBitmapData` so we don't have to cut out the region before drawing to canvas and so we can draw directly from atlas. This saves a lot of work when having `SubBitmapData`s inside `cacheAsBitmap`'d containers.

---

Disclaimer: I'm not very satisfied with the code here and there's probably still some issues with calculations and HDPI to be found. Also I haven't done the "generic function to get a sub-region to use for both GL and canvas" like we discussed with @Neu2o before. But everything I checked in the game looks correct and we already avoid a lot of CPU work with this, so I'd like to get this merged and build on top of this before my brain melts completely ;-)

--- 

With this change, the `__prepareImage` method is now only used in three places (I think):
 - bitmap-fill graphics drawing
 - copyPixels
 - Stage3D texture uploads

Ideally, all of them should be avoided for the best rendering performance, although we can probably do something with `copyPixels` so it copies pixels also directly from the parent image. Though with rotated SubBitmapData's this is not very trivial, and of course out of scope of this PR.