### PR TITLE
always re-render TextField and Graphics when pixelRatio differs from the previous render

### DIFF
--- a/src/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -1112,7 +1112,8 @@ class CanvasGraphics {
 		
 		graphics.__update ();
 		
-		if (graphics.__dirty) {
+		var dirty = graphics.__dirty || (graphics.__bitmap != null && @:privateAccess graphics.__bitmap.__pixelRatio != renderSession.pixelRatio);
+		if (dirty) {
 			
 			hitTesting = false;
 			

--- a/src/openfl/_internal/renderer/canvas/CanvasTextField.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasTextField.hx
@@ -65,7 +65,8 @@ class CanvasTextField {
 		
 		graphics.__update ();
 		
-		if (textField.__dirty || graphics.__dirty) {
+		var dirty = textField.__dirty || graphics.__dirty || (graphics.__bitmap != null && @:privateAccess graphics.__bitmap.__pixelRatio != pixelRatio);
+		if (dirty) {
 			
 			var width = graphics.__width;
 			var height = graphics.__height;


### PR DESCRIPTION
As discussed on Slack, we can't use the cached canvas+bitmapdata of TextField or Graphics if it was rendered with different pixelRatio, so we must consider it dirty.

This can happen when using `BitmapData.draw` API, which will always have pixelRatio=1, while the cached canvas can have different (screen) pixel ratio. The correct way to fix this would be to have a render-to-canvas method that doesn't change DisplayObject's internal state, but that's a refactoring for the future.