### PR TITLE
Batch rendering for display objects

### DIFF
--- a/src/openfl/_internal/renderer/RenderSession.hx
+++ b/src/openfl/_internal/renderer/RenderSession.hx
@@ -16,6 +16,7 @@ import lime.graphics.RendererType;
 //import openfl._internal.renderer.opengl.utils.ShaderManager;
 //import openfl._internal.renderer.opengl.utils.SpriteBatch;
 //import openfl._internal.renderer.opengl.utils.StencilManager;
+import openfl._internal.renderer.opengl.batcher.BatchRenderer;
 import openfl.display.BlendMode;
 import openfl.geom.Matrix;
 import openfl.geom.Point;
@@ -38,6 +39,7 @@ class RenderSession {
 	public var gl(default, set):GLRenderContext;
 	// public var lockTransform:Bool;
 	public var renderer:AbstractRenderer;
+	public var batcher:BatchRenderer;
 	public var renderType:RendererType;
 	public var roundPixels:Bool;
 	public var transformProperty:String;

--- a/src/openfl/_internal/renderer/opengl/GLBitmap.hx
+++ b/src/openfl/_internal/renderer/opengl/GLBitmap.hx
@@ -31,6 +31,11 @@ class GLBitmap {
 		
 		if (bitmap.__bitmapData != null && bitmap.__bitmapData.__isValid) {
 			
+			renderSession.maskManager.pushObject (bitmap);
+			renderSession.batcher.render (bitmap.__getBatchQuad (renderSession));
+			renderSession.maskManager.popObject (bitmap);
+			return;
+
 			var renderer:GLRenderer = cast renderSession.renderer;
 			var gl = renderSession.gl;
 			

--- a/src/openfl/_internal/renderer/opengl/GLMaskManager.hx
+++ b/src/openfl/_internal/renderer/opengl/GLMaskManager.hx
@@ -51,6 +51,9 @@ class GLMaskManager extends AbstractMaskManager {
 	
 	public override function pushMask (mask:DisplayObject):Void {
 		
+		// flush everything in the current batch, since we're rendering stuff differently now
+		renderSession.batcher.flush ();
+
 		if (stencilReference == 0) {
 			
 			gl.enable (gl.STENCIL_TEST);
@@ -64,6 +67,10 @@ class GLMaskManager extends AbstractMaskManager {
 		gl.colorMask (false, false, false, false);
 		
 		mask.__renderGLMask (renderSession);
+		
+		// flush batched mask renders, because we're changing state again
+		renderSession.batcher.flush ();
+		
 		maskObjects.push (mask);
 		stencilReference++;
 		
@@ -133,6 +140,9 @@ class GLMaskManager extends AbstractMaskManager {
 		
 		if (stencilReference == 0) return;
 		
+		// flush whatever was rendered behind the mask, because we're changing state
+		renderSession.batcher.flush ();
+		
 		var mask = maskObjects.pop ();
 		if (stencilReference > 1) {
 			
@@ -141,6 +151,10 @@ class GLMaskManager extends AbstractMaskManager {
 			gl.colorMask (false, false, false, false);
 			
 			mask.__renderGLMask (renderSession);
+			
+			// flush batched mask renders, because we're changing state again
+			renderSession.batcher.flush ();
+
 			stencilReference--;
 			
 			gl.stencilOp (gl.KEEP, gl.KEEP, gl.KEEP);
@@ -196,6 +210,9 @@ class GLMaskManager extends AbstractMaskManager {
 	
 	
 	private function scissorRect (rect:Rectangle = null):Void {
+		
+		// flush batched renders so they are drawn before the scissor call 
+		renderSession.batcher.flush ();
 		
 		if (rect != null) {
 			

--- a/src/openfl/_internal/renderer/opengl/GLShape.hx
+++ b/src/openfl/_internal/renderer/opengl/GLShape.hx
@@ -47,6 +47,11 @@ class GLShape {
 			
 			if (graphics.__bitmap != null && graphics.__visible) {
 				
+				renderSession.maskManager.pushObject (shape);
+				renderSession.batcher.render(graphics.__getBatchQuad(renderSession, shape.__worldAlpha, shape.__worldColorTransform, shape.__worldBlendMode));
+				renderSession.maskManager.popObject (shape);
+				return;
+				
 				var renderer:GLRenderer = cast renderSession.renderer;
 				var gl = renderSession.gl;
 				

--- a/src/openfl/_internal/renderer/opengl/GLTilemap.hx
+++ b/src/openfl/_internal/renderer/opengl/GLTilemap.hx
@@ -44,6 +44,9 @@ class GLTilemap {
 		
 		if (tilemap.__tileArray == null || tilemap.__tileArray.length == 0) return;
 		
+		// break the batch as we don't batch tilemaps for now
+		renderSession.batcher.flush ();
+		
 		var renderer:GLRenderer = cast renderSession.renderer;
 		var gl = renderSession.gl;
 		
@@ -187,6 +190,9 @@ class GLTilemap {
 		tilemap.__updateTileArray ();
 		
 		if (tilemap.__tileArray == null || tilemap.__tileArray.length == 0) return;
+		
+		// break the batch as we don't batch tilemaps for now
+		renderSession.batcher.flush ();
 		
 		var renderer:GLRenderer = cast renderSession.renderer;
 		var gl = renderSession.gl;

--- a/src/openfl/_internal/renderer/opengl/batcher/BatchRenderer.hx
+++ b/src/openfl/_internal/renderer/opengl/batcher/BatchRenderer.hx
@@ -38,6 +38,8 @@ class BatchRenderer {
 	var textureTick = 0;
 
 	public var projectionMatrix:Float32Array;
+	
+	static inline var floatsPerQuad = MultiTextureShader.floatPerVertex * 4;
 
 	public function new(gl:GLRenderContext, blendModeManager:GLBlendModeManager, shaderManager:GLShaderManager, maxQuads:Int) {
 		this.gl = gl;
@@ -56,7 +58,6 @@ class BatchRenderer {
 		// smallest one can render just one quad, biggest one can render maximum amount
 		vertexBufferDatas = [];
 		var i = 1, l = nextPow2(maxQuads);
-		var floatsPerQuad = MultiTextureShader.floatPerVertex * 4;
 		while (i <= l) {
 			vertexBufferDatas.push(new Float32Array(i * floatsPerQuad));
 			i *= 2;
@@ -259,7 +260,7 @@ class BatchRenderer {
 			setVertex(2);
 			setVertex(3);
 
-			vertexBufferIndex += MultiTextureShader.floatPerVertex * 4;
+			vertexBufferIndex += floatsPerQuad;
 			quadIndex++;
 		}
 

--- a/src/openfl/_internal/renderer/opengl/batcher/BatchRenderer.hx
+++ b/src/openfl/_internal/renderer/opengl/batcher/BatchRenderer.hx
@@ -195,8 +195,9 @@ class BatchRenderer {
 								break;
 							}
 						}
-						if (nextTexture.textureUnitId == -1)
-							throw "WAT";
+						if (nextTexture.textureUnitId == -1) {
+							throw "Unable to find free texture unit for the batch render group! This should NOT happen!";
+						}
 					}
 
 					// mark the texture as enabled in this group

--- a/src/openfl/_internal/renderer/opengl/batcher/BatchRenderer.hx
+++ b/src/openfl/_internal/renderer/opengl/batcher/BatchRenderer.hx
@@ -56,8 +56,9 @@ class BatchRenderer {
 		// smallest one can render just one quad, biggest one can render maximum amount
 		vertexBufferDatas = [];
 		var i = 1, l = nextPow2(maxQuads);
+		var floatsPerQuad = MultiTextureShader.floatPerVertex * 4;
 		while (i <= l) {
-			vertexBufferDatas.push(new Float32Array(i * 4 * MultiTextureShader.floatPerVertex));
+			vertexBufferDatas.push(new Float32Array(i * floatsPerQuad));
 			i *= 2;
 		}
 

--- a/src/openfl/_internal/renderer/opengl/batcher/BatchRenderer.hx
+++ b/src/openfl/_internal/renderer/opengl/batcher/BatchRenderer.hx
@@ -1,0 +1,354 @@
+package openfl._internal.renderer.opengl.batcher;
+
+import haxe.ds.Vector;
+
+import lime.utils.Float32Array;
+import lime.utils.UInt16Array;
+import lime.graphics.GLRenderContext;
+import lime.graphics.opengl.GLBuffer;
+import openfl.display.BlendMode;
+import openfl._internal.renderer.opengl.GLBlendModeManager;
+import openfl._internal.renderer.opengl.GLShaderManager;
+import openfl._internal.renderer.opengl.batcher.BitHacks.*;
+import openfl._internal.renderer.opengl.batcher.Quad;
+
+#if gl_stats
+import openfl._internal.renderer.opengl.stats.GLStats;
+import openfl._internal.renderer.opengl.stats.DrawCallContext;
+#end
+
+// inspired by pixi.js SpriteRenderer
+class BatchRenderer {
+	var gl:GLRenderContext;
+	var blendModeManager:GLBlendModeManager;
+	var shaderManager:GLShaderManager;
+	var maxQuads:Int;
+	var maxTextures:Int;
+
+	var shader:MultiTextureShader;
+	var indexBuffer:GLBuffer;
+	var vertexBuffer:GLBuffer;
+	var vertexBufferDatas:Array<Float32Array>;
+
+	var renderedQuadCount:Int;
+	var renderedQuads:Array<Quad>;
+	var groups:Vector<RenderGroup>;
+	var boundTextures:Vector<TextureData>;
+	var tick = 0;
+	var textureTick = 0;
+
+	public var projectionMatrix:Float32Array;
+
+	public function new(gl:GLRenderContext, blendModeManager:GLBlendModeManager, shaderManager:GLShaderManager, maxQuads:Int) {
+		this.gl = gl;
+		this.blendModeManager = blendModeManager;
+		this.shaderManager = shaderManager;
+		this.maxQuads = maxQuads;
+
+		// determine amount of textures we can draw at once and generate a shader for that
+		maxTextures = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS);
+		shader = new MultiTextureShader(gl, maxTextures);
+
+		// a singleton vector we use to track texture binding when rendering
+		boundTextures = new Vector(maxTextures);
+
+		// preallocate blocks of memory for vertex buffers of different sizes
+		// smallest one can render just one quad, biggest one can render maximum amount
+		vertexBufferDatas = [];
+		var i = 1, l = nextPow2(maxQuads);
+		while (i <= l) {
+			vertexBufferDatas.push(new Float32Array(i * 4 * MultiTextureShader.floatPerVertex));
+			i *= 2;
+		}
+
+		// create the vertex buffer for further uploading
+		vertexBuffer = gl.createBuffer();
+
+		// preallocate a static index buffer for rendering any number of quads
+		var indices = createIndicesForQuads(maxQuads);
+		indexBuffer = gl.createBuffer();
+		gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+		gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices.byteLength, indices, gl.STATIC_DRAW);
+
+		// preallocate render group objects for any number of quads (worst case - 1 group per quad)
+		groups = new Vector(maxQuads);
+		for (i in 0...maxQuads) {
+			groups[i] = new RenderGroup();
+		}
+
+		// the quads array is allocated once, grows when we add new quads, but never shrinks, so we store length in a separate var
+		renderedQuads = [];
+		renderedQuadCount = 0;
+	}
+
+	/** schedule quad for rendering **/
+	public function render(quad:Quad) {
+		if (renderedQuadCount >= maxQuads) {
+			flush();
+		}
+		renderedQuads[renderedQuadCount++] = quad;
+	}
+
+	/** render all the quads we collected **/
+	public function flush() {
+		if (renderedQuadCount == 0) {
+			return;
+		}
+
+		// use local vars to save some field access
+		var gl = this.gl;
+		var renderedQuads = this.renderedQuads;
+		var boundTextures = this.boundTextures;
+		var groups = this.groups;
+
+		// choose vertex buffer based on the amount of quads
+		var bufferIndex = log2(nextPow2(renderedQuadCount));
+		var vertexBufferData = vertexBufferDatas[bufferIndex];
+
+		var vertexBufferIndex = 0;
+		var currentTexture = null;
+		var blendMode = renderedQuads[0].blendMode;
+
+		var currentGroup;
+		var groupCount = 0;
+		var quadIndex = 0;
+
+		inline function startNextGroup() {
+			currentGroup = groups[groupCount];
+			currentGroup.textureCount = 0;
+			currentGroup.start = quadIndex;
+			currentGroup.blendMode = blendMode;
+			// we always increase the tick when staring a new render group, so all textures become "disabled" and need to be processed
+			tick++;
+			groupCount++;
+		}
+
+		inline function finishCurrentGroup() {
+			currentGroup.size = quadIndex - currentGroup.start;
+		}
+
+		for (i in 0...maxTextures) {
+			boundTextures[i] = null;
+		}
+
+		// initialize first group
+		startNextGroup();
+
+		// iterate over quads, fill the vertex buffer and create render groups
+		while (quadIndex < renderedQuadCount) {
+			var quad = renderedQuads[quadIndex];
+			renderedQuads[quadIndex] = null;
+
+			var nextTexture = quad.texture.data;
+
+			if (blendMode != quad.blendMode) {
+				blendMode = quad.blendMode;
+				currentTexture = null;
+
+				finishCurrentGroup();
+				startNextGroup();
+			}
+
+			// if the texture has changed - we need to either pack it into the current render group or create the next one
+			// and since on the first iteration the `currentTexture` is null, it's always "changed"
+			if (currentTexture != nextTexture) {
+				currentTexture = nextTexture;
+
+				// if the texture's tick and current tick are equal, that means
+				// that the texture was already enabled in the current group
+				// and we don't need to do anything, otherwise...
+				if (currentTexture.enabledTick != tick) {
+
+					// if the current group is already full of textures, finish it and start a new one
+					if (currentGroup.textureCount == maxTextures) {
+						finishCurrentGroup();
+						startNextGroup();
+					}
+
+					// if the texture hasn't yet been bound to a texture unit this render, we need to choose one
+					if (nextTexture.textureUnitId == -1) {
+						// iterate over possible texture "slots"
+						for (i in 0...maxTextures) {
+							// we use "texture tick" for calculating texture unit,
+							// so we always start checking with the next texture unit,
+							// relative to previous binding
+							var textureUnit = (i + textureTick) % maxTextures;
+
+							// if there's no bound texture in this slot, or that texture
+							// wasn't used in this group (ticks are different), we can use this slot!
+							var boundTexture = boundTextures[textureUnit];
+							if (boundTexture == null || boundTexture.enabledTick != tick) {
+								// if there was a texture in this slot - unbind it, since we're replacing it
+								if (boundTexture != null) {
+									boundTexture.textureUnitId = -1;
+								}
+
+								// assign this texture to the texture unit
+								nextTexture.textureUnitId = textureUnit;
+								boundTextures[textureUnit] = nextTexture;
+
+								// increase the tick so next time we'll start looking directly from the next texture unit
+								textureTick++;
+
+								// and we're done here
+								break;
+							}
+						}
+						if (nextTexture.textureUnitId == -1)
+							throw "WAT";
+					}
+
+					// mark the texture as enabled in this group
+					nextTexture.enabledTick = tick;
+					// add the texture to the group textures array
+					currentGroup.textures[currentGroup.textureCount] = nextTexture;
+					// save the texture unit number separately as it can change when processing next group
+					currentGroup.textureUnits[currentGroup.textureCount] = nextTexture.textureUnitId;
+					currentGroup.textureSmoothing[currentGroup.textureCount] = quad.smoothing;
+					currentGroup.textureCount++;
+				}
+			}
+
+			// fill the vertex buffer with vertex and texture coordinates, as well as the texture id
+			var vertexData = quad.vertexData;
+			var uvs = quad.texture.uvs;
+			var textureUnitId = nextTexture.textureUnitId;
+			var alpha = quad.alpha;
+			var colorTransform = quad.colorTransform;
+
+			// trace('Group $groupCount uses texture $textureUnitId');
+
+			inline function setVertex(i) {
+				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 0] = vertexData[i * 2 + 0];
+				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 1] = vertexData[i * 2 + 1];
+
+				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 2] = uvs[i * 2 + 0];
+				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 3] = uvs[i * 2 + 1];
+
+				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 4] = textureUnitId;
+
+				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 5] = alpha;
+
+				if (colorTransform != null) {
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 6] = colorTransform.redOffset / 255;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 7] = colorTransform.greenOffset / 255;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 8] = colorTransform.blueOffset / 255;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 9] = colorTransform.alphaOffset / 255;
+
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 10] = colorTransform.redMultiplier;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 11] = colorTransform.greenMultiplier;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 12] = colorTransform.blueMultiplier;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 13] = colorTransform.alphaMultiplier;
+				} else {
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 6] = 0;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 7] = 0;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 8] = 0;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 9] = 0;
+
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 10] = 1;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 11] = 1;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 12] = 1;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 13] = 1;
+				}
+			}
+
+			setVertex(0);
+			setVertex(1);
+			setVertex(2);
+			setVertex(3);
+
+			vertexBufferIndex += MultiTextureShader.floatPerVertex * 4;
+			quadIndex++;
+		}
+
+		// finish the current group
+		finishCurrentGroup();
+
+		// disable the current OpenFL shader so it'll be re-enabled properly on next non-batched openfl render
+		// this is needed because we don't use ShaderManager to set our shader. Ideally we should do that, but
+		// this will requires some rework for the whole OpenFL shader system, which we'll do when we'll fork away for good 
+		shaderManager.setShader(null);
+		
+		shader.enable(projectionMatrix);
+
+		// bind the index buffer
+		gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+
+		// upload vertex data and setup attribute pointers
+		gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+		gl.bufferData(gl.ARRAY_BUFFER, vertexBufferData.byteLength, vertexBufferData, gl.STREAM_DRAW);
+
+		var stride = MultiTextureShader.floatPerVertex * Float32Array.BYTES_PER_ELEMENT;
+		gl.vertexAttribPointer(shader.aVertexPosition, 2, gl.FLOAT, false, stride, 0);
+		gl.vertexAttribPointer(shader.aTextureCoord, 2, gl.FLOAT, false, stride, 2 * Float32Array.BYTES_PER_ELEMENT);
+		gl.vertexAttribPointer(shader.aTextureId, 1, gl.FLOAT, false, stride, 4 * Float32Array.BYTES_PER_ELEMENT);
+		gl.vertexAttribPointer(shader.aAlpha, 1, gl.FLOAT, false, stride, 5 * Float32Array.BYTES_PER_ELEMENT);
+		gl.vertexAttribPointer(shader.aColorOffset, 4, gl.FLOAT, false, stride, 6 * Float32Array.BYTES_PER_ELEMENT);
+		gl.vertexAttribPointer(shader.aColorMultiplier, 4, gl.FLOAT, false, stride, 10 * Float32Array.BYTES_PER_ELEMENT);
+
+		// iterate over groups and render them
+		for (i in 0...groupCount) {
+			var group = groups[i];
+			// trace('Rendering group ${i + 1} (${group.size})');
+
+			// bind this group's textures
+			for (i in 0...group.textureCount) {
+				currentTexture = group.textures[i];
+				// trace('Activating texture at ${group.textureUnits[i]}: ${currentTexture.glTexture}');
+				gl.activeTexture(gl.TEXTURE0 + group.textureUnits[i]);
+				gl.bindTexture(gl.TEXTURE_2D, currentTexture.glTexture);
+
+				if (group.textureSmoothing[i]) {
+					gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+					gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+				} else {
+					gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+					gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+				}
+
+				currentTexture.textureUnitId = -1; // clear the binding for subsequent flush calls
+			}
+
+			blendModeManager.setBlendMode(group.blendMode);
+
+			// draw this group's slice of vertices
+			gl.drawElements(gl.TRIANGLES, group.size * 6, gl.UNSIGNED_SHORT, group.start * 6 * UInt16Array.BYTES_PER_ELEMENT);
+
+			#if gl_stats
+				GLStats.incrementDrawCall (DrawCallContext.STAGE);
+			#end
+		}
+
+		// we've rendered everything \o/ reset the quad count
+		renderedQuadCount = 0;
+	}
+
+	/** creates an pre-filled index buffer data for rendering triangles **/
+	static function createIndicesForQuads(numQuads:Int):UInt16Array {
+		var totalIndices = numQuads * 3 * 2; // 2 triangles of 3 verties per quad
+		var indices = new UInt16Array(totalIndices);
+		var i = 0, j = 0;
+		while (i < totalIndices) {
+			indices[i + 0] = j + 0;
+			indices[i + 1] = j + 1;
+			indices[i + 2] = j + 2;
+			indices[i + 3] = j + 0;
+			indices[i + 4] = j + 2;
+			indices[i + 5] = j + 3;
+			i += 6;
+			j += 4;
+		}
+		return indices;
+	}
+}
+
+private class RenderGroup {
+	public var textures = new Array<TextureData>();
+	public var textureUnits = new Array<Int>();
+	public var textureSmoothing = new Array<Bool>();
+	public var textureCount = 0;
+	public var size = 0;
+	public var start = 0;
+	public var blendMode:BlendMode;
+	public function new() {}
+}

--- a/src/openfl/_internal/renderer/opengl/batcher/BatchRenderer.hx
+++ b/src/openfl/_internal/renderer/opengl/batcher/BatchRenderer.hx
@@ -39,7 +39,7 @@ class BatchRenderer {
 
 	public var projectionMatrix:Float32Array;
 	
-	static inline var floatsPerQuad = MultiTextureShader.floatPerVertex * 4;
+	static inline var floatsPerQuad = MultiTextureShader.floatsPerVertex * 4;
 
 	public function new(gl:GLRenderContext, blendModeManager:GLBlendModeManager, shaderManager:GLShaderManager, maxQuads:Int) {
 		this.gl = gl;
@@ -222,36 +222,36 @@ class BatchRenderer {
 			// trace('Group $groupCount uses texture $textureUnitId');
 
 			inline function setVertex(i) {
-				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 0] = vertexData[i * 2 + 0];
-				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 1] = vertexData[i * 2 + 1];
+				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 0] = vertexData[i * 2 + 0];
+				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 1] = vertexData[i * 2 + 1];
 
-				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 2] = uvs[i * 2 + 0];
-				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 3] = uvs[i * 2 + 1];
+				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 2] = uvs[i * 2 + 0];
+				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 3] = uvs[i * 2 + 1];
 
-				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 4] = textureUnitId;
+				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 4] = textureUnitId;
 
-				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 5] = alpha;
+				vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 5] = alpha;
 
 				if (colorTransform != null) {
-					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 6] = colorTransform.redOffset / 255;
-					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 7] = colorTransform.greenOffset / 255;
-					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 8] = colorTransform.blueOffset / 255;
-					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 9] = colorTransform.alphaOffset / 255;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 6] = colorTransform.redOffset / 255;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 7] = colorTransform.greenOffset / 255;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 8] = colorTransform.blueOffset / 255;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 9] = colorTransform.alphaOffset / 255;
 
-					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 10] = colorTransform.redMultiplier;
-					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 11] = colorTransform.greenMultiplier;
-					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 12] = colorTransform.blueMultiplier;
-					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 13] = colorTransform.alphaMultiplier;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 10] = colorTransform.redMultiplier;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 11] = colorTransform.greenMultiplier;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 12] = colorTransform.blueMultiplier;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 13] = colorTransform.alphaMultiplier;
 				} else {
-					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 6] = 0;
-					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 7] = 0;
-					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 8] = 0;
-					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 9] = 0;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 6] = 0;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 7] = 0;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 8] = 0;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 9] = 0;
 
-					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 10] = 1;
-					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 11] = 1;
-					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 12] = 1;
-					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatPerVertex + 13] = 1;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 10] = 1;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 11] = 1;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 12] = 1;
+					vertexBufferData[vertexBufferIndex + i * MultiTextureShader.floatsPerVertex + 13] = 1;
 				}
 			}
 
@@ -281,7 +281,7 @@ class BatchRenderer {
 		gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
 		gl.bufferData(gl.ARRAY_BUFFER, vertexBufferData.byteLength, vertexBufferData, gl.STREAM_DRAW);
 
-		var stride = MultiTextureShader.floatPerVertex * Float32Array.BYTES_PER_ELEMENT;
+		var stride = MultiTextureShader.floatsPerVertex * Float32Array.BYTES_PER_ELEMENT;
 		gl.vertexAttribPointer(shader.aVertexPosition, 2, gl.FLOAT, false, stride, 0);
 		gl.vertexAttribPointer(shader.aTextureCoord, 2, gl.FLOAT, false, stride, 2 * Float32Array.BYTES_PER_ELEMENT);
 		gl.vertexAttribPointer(shader.aTextureId, 1, gl.FLOAT, false, stride, 4 * Float32Array.BYTES_PER_ELEMENT);

--- a/src/openfl/_internal/renderer/opengl/batcher/BitHacks.hx
+++ b/src/openfl/_internal/renderer/opengl/batcher/BitHacks.hx
@@ -1,0 +1,24 @@
+package openfl._internal.renderer.opengl.batcher;
+
+class BitHacks {
+	// http://graphics.stanford.edu/~seander/bithacks.html#IntegerLog
+	public static function log2(v:Int):Int {
+		var r, shift;
+		r =     if (v > 0xFFFF) 1 << 4 else 0; v >>>= r;
+		shift = if (v > 0xFF  ) 1 << 3 else 0; v >>>= shift; r |= shift;
+		shift = if (v > 0xF   ) 1 << 2 else 0; v >>>= shift; r |= shift;
+		shift = if (v > 0x3   ) 1 << 1 else 0; v >>>= shift; r |= shift;
+		return r | (v >> 1);
+	}
+
+	// http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+	public static function nextPow2(v:Int):Int {
+		v--;
+		v |= v >>> 1;
+		v |= v >>> 2;
+		v |= v >>> 4;
+		v |= v >>> 8;
+		v |= v >>> 16;
+		return v + 1;
+	}
+}

--- a/src/openfl/_internal/renderer/opengl/batcher/MultiTextureShader.hx
+++ b/src/openfl/_internal/renderer/opengl/batcher/MultiTextureShader.hx
@@ -21,7 +21,7 @@ class MultiTextureShader {
 	var uProjMatrix:GLUniformLocation;
 
 	// x, y, u, v, texId, alpha, colorMult, colorOfs
-	public static inline var floatPerVertex = 2 + 2 + 1 + 1 + 4 + 4;
+	public static inline var floatsPerVertex = 2 + 2 + 1 + 1 + 4 + 4;
 
 	public function new(gl:GLRenderContext, maxTextures:Int) {
 		this.gl = gl;

--- a/src/openfl/_internal/renderer/opengl/batcher/MultiTextureShader.hx
+++ b/src/openfl/_internal/renderer/opengl/batcher/MultiTextureShader.hx
@@ -1,0 +1,134 @@
+package openfl._internal.renderer.opengl.batcher;
+
+import lime.graphics.GLRenderContext;
+import lime.graphics.opengl.GLProgram;
+import lime.graphics.opengl.GLUniformLocation;
+import lime.utils.Float32Array;
+import lime.utils.Int32Array;
+import lime.utils.GLUtils;
+
+class MultiTextureShader {
+	var program:GLProgram;
+	var gl:GLRenderContext;
+
+	public var aVertexPosition(default,null):Int;
+	public var aTextureCoord(default,null):Int;
+	public var aTextureId(default,null):Int;
+	public var aAlpha(default,null):Int;
+	public var aColorOffset(default,null):Int;
+	public var aColorMultiplier(default,null):Int;
+
+	var uProjMatrix:GLUniformLocation;
+
+	// x, y, u, v, texId, alpha, colorMult, colorOfs
+	public static inline var floatPerVertex = 2 + 2 + 1 + 1 + 4 + 4;
+
+	public function new(gl:GLRenderContext, maxTextures:Int) {
+		this.gl = gl;
+
+		var fsSource = generateMultiTextureFragmentShaderSource(maxTextures);
+		program = GLUtils.createProgram(vsSource, fsSource);
+
+		aVertexPosition = gl.getAttribLocation(program, 'aVertexPosition');
+		aTextureCoord = gl.getAttribLocation(program, 'aTextureCoord');
+		aTextureId = gl.getAttribLocation(program, 'aTextureId');
+		aAlpha = gl.getAttribLocation(program, 'aAlpha');
+		aColorOffset = gl.getAttribLocation(program, 'aColorOffset');
+		aColorMultiplier = gl.getAttribLocation(program, 'aColorMultiplier');
+		uProjMatrix = gl.getUniformLocation(program, "uProjMatrix");
+
+		gl.useProgram(program);
+		gl.uniform1iv(gl.getUniformLocation(program, 'uSamplers'), maxTextures, new Int32Array([for (i in 0...maxTextures) i]));
+	}
+
+	public function enable(projectionMatrix:Float32Array) {
+		gl.useProgram(program);
+
+		gl.enableVertexAttribArray(aVertexPosition);
+		gl.enableVertexAttribArray(aTextureCoord);
+		gl.enableVertexAttribArray(aTextureId);
+		gl.enableVertexAttribArray(aAlpha);
+		gl.enableVertexAttribArray(aColorOffset);
+		gl.enableVertexAttribArray(aColorMultiplier);
+
+		gl.uniformMatrix4fv(uProjMatrix, 0, false, projectionMatrix);
+	}
+
+	static function generateMultiTextureFragmentShaderSource(numTextures:Int):String {
+		var select = [];
+		for (i in 0...numTextures) {
+			var cond = if (i > 0) "else " else "";
+			if (i < numTextures - 1) cond += 'if (textureId == $i.0) ';
+			select.push('\t\t\t\t${cond}color = texture2D(uSamplers[$i], vTextureCoord);');
+		}
+		return '
+			precision mediump float;
+
+			varying vec2 vTextureCoord;
+			varying float vTextureId;
+			varying float vAlpha;
+			varying vec4 vColorMultiplier;
+			varying vec4 vColorOffset;
+
+			uniform sampler2D uSamplers[$numTextures];
+
+			void main(void) {
+				float textureId = floor(vTextureId+0.5);
+				vec4 color;
+${select.join("\n")}
+
+				if (color.a == 0.0) {
+
+					gl_FragColor = vec4 (0.0, 0.0, 0.0, 0.0);
+
+				} else {
+					color = vec4 (color.rgb / color.a, color.a);
+
+					mat4 colorMultiplier;
+					colorMultiplier[0] = vec4(vColorMultiplier.r, 0, 0, 0);
+					colorMultiplier[1] = vec4(0, vColorMultiplier.g, 0, 0);
+					colorMultiplier[2] = vec4(0, 0, vColorMultiplier.b, 0);
+					colorMultiplier[3] = vec4(0, 0, 0, vColorMultiplier.a);
+
+					color = vColorOffset + (color * colorMultiplier);
+
+					if (color.a > 0.0) {
+
+						gl_FragColor = vec4 (color.rgb * color.a * vAlpha, color.a * vAlpha);
+
+					} else {
+
+						gl_FragColor = vec4 (0.0, 0.0, 0.0, 0.0);
+
+					}
+				}
+			}
+		';
+	}
+
+	static inline var vsSource = '
+		attribute vec2 aVertexPosition;
+		attribute vec2 aTextureCoord;
+		attribute float aTextureId;
+		attribute float aAlpha;
+		attribute vec4 aColorMultiplier;
+		attribute vec4 aColorOffset;
+
+		uniform mat4 uProjMatrix;
+
+		varying vec2 vTextureCoord;
+		varying float vTextureId;
+		varying float vAlpha;
+		varying vec4 vColorMultiplier;
+		varying vec4 vColorOffset;
+
+		void main(void) {
+			gl_Position = uProjMatrix * vec4(aVertexPosition, 0, 1);
+			vTextureCoord = aTextureCoord;
+			vTextureId = aTextureId;
+			vAlpha = aAlpha;
+			vColorMultiplier = aColorMultiplier;
+			vColorOffset = aColorOffset;
+		}
+	';
+}

--- a/src/openfl/_internal/renderer/opengl/batcher/Quad.hx
+++ b/src/openfl/_internal/renderer/opengl/batcher/Quad.hx
@@ -9,7 +9,7 @@ class Quad {
 	public var vertexData(default,null):Float32Array;
 
 	/** Link to the texture information **/
-	public var texture:Texture;
+	public var texture:QuadTextureData;
 
 	public var alpha:Float;
 

--- a/src/openfl/_internal/renderer/opengl/batcher/Quad.hx
+++ b/src/openfl/_internal/renderer/opengl/batcher/Quad.hx
@@ -1,0 +1,27 @@
+package openfl._internal.renderer.opengl.batcher;
+
+import lime.utils.Float32Array;
+import openfl.display.BlendMode;
+import openfl.geom.ColorTransform;
+
+class Quad {
+	/** Absolute vertex coordinates **/
+	public var vertexData(default,null):Float32Array;
+
+	/** Link to the texture information **/
+	public var texture:Texture;
+
+	public var alpha:Float;
+
+	public var colorTransform:ColorTransform;
+
+	public var blendMode:BlendMode;
+
+	public var smoothing:Bool;
+
+	public function new() {
+		vertexData = new Float32Array(4 * 2);
+		alpha = 1;
+		smoothing = false;
+	}
+}

--- a/src/openfl/_internal/renderer/opengl/batcher/QuadTextureData.hx
+++ b/src/openfl/_internal/renderer/opengl/batcher/QuadTextureData.hx
@@ -2,7 +2,7 @@ package openfl._internal.renderer.opengl.batcher;
 
 import lime.utils.Float32Array;
 
-class Texture {
+class QuadTextureData {
 	public var data(default,null):TextureData;
 
 	/** Texture coordinates (0x0-1x1 for full texture, some region for atlas sub-textures) **/
@@ -15,12 +15,12 @@ class Texture {
 		0, 1
 	]);
 
-	public static inline function createFullFrame(data:TextureData):Texture {
-		return new Texture(data, fullFrameUVs);
+	public static inline function createFullFrame(data:TextureData):QuadTextureData {
+		return new QuadTextureData(data, fullFrameUVs);
 	}
 
-	public static inline function createRegion(data:TextureData, u0:Float, v0:Float, u1:Float, v1:Float, u2:Float, v2:Float, u3:Float, v3:Float):Texture {
-		return new Texture(data, new Float32Array([
+	public static inline function createRegion(data:TextureData, u0:Float, v0:Float, u1:Float, v1:Float, u2:Float, v2:Float, u3:Float, v3:Float):QuadTextureData {
+		return new QuadTextureData(data, new Float32Array([
 			u0, v0,
 			u1, v1,
 			u2, v2,

--- a/src/openfl/_internal/renderer/opengl/batcher/Texture.hx
+++ b/src/openfl/_internal/renderer/opengl/batcher/Texture.hx
@@ -1,0 +1,35 @@
+package openfl._internal.renderer.opengl.batcher;
+
+import lime.utils.Float32Array;
+
+class Texture {
+	public var data(default,null):TextureData;
+
+	/** Texture coordinates (0x0-1x1 for full texture, some region for atlas sub-textures) **/
+	public var uvs(default,null):Float32Array;
+
+	static var fullFrameUVs = new Float32Array([
+		0, 0,
+		1, 0,
+		1, 1,
+		0, 1
+	]);
+
+	public static inline function createFullFrame(data:TextureData):Texture {
+		return new Texture(data, fullFrameUVs);
+	}
+
+	public static inline function createRegion(data:TextureData, u0:Float, v0:Float, u1:Float, v1:Float, u2:Float, v2:Float, u3:Float, v3:Float):Texture {
+		return new Texture(data, new Float32Array([
+			u0, v0,
+			u1, v1,
+			u2, v2,
+			u3, v3
+		]));
+	}
+
+	function new(data, uvs) {
+		this.data = data;
+		this.uvs = uvs;
+	}
+}

--- a/src/openfl/_internal/renderer/opengl/batcher/TextureData.hx
+++ b/src/openfl/_internal/renderer/opengl/batcher/TextureData.hx
@@ -1,0 +1,16 @@
+package openfl._internal.renderer.opengl.batcher;
+
+import lime.graphics.opengl.GLTexture;
+
+class TextureData {
+	/** Actual GL texture **/
+	public var glTexture:GLTexture;
+
+	/** Batcher-specific data about this texture (so we don't have to allocate more storage and do lookups) **/
+	public var textureUnitId = -1;
+	public var enabledTick = 0;
+
+	public function new(glTexture) {
+		this.glTexture = glTexture;
+	}
+}

--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -5,6 +5,8 @@ import openfl._internal.renderer.cairo.CairoBitmap;
 import openfl._internal.renderer.canvas.CanvasBitmap;
 import openfl._internal.renderer.dom.DOMBitmap;
 import openfl._internal.renderer.opengl.GLBitmap;
+import openfl._internal.renderer.opengl.GLRenderer;
+import openfl._internal.renderer.opengl.batcher.Quad;
 import openfl._internal.renderer.RenderSession;
 import openfl.geom.Matrix;
 import openfl.geom.Point;
@@ -40,6 +42,8 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 	private var __bitmapData:BitmapData;
 	private var __imageVersion:Int;
 	
+	var __batchQuad:Quad;
+	var __batchQuadDirty:Bool = true;
 	
 	#if openfljs
 	private static function __init__ () {
@@ -234,6 +238,37 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 	}
 	
 	
+	function __getBatchQuad (renderSession:RenderSession):Quad {
+		
+		if (__batchQuadDirty) {
+			if (__batchQuad == null) {
+				__batchQuad = new Quad ();
+			}
+			
+			var snapToPixel = renderSession.roundPixels || __snapToPixel ();
+			var transform = (cast renderSession.renderer : GLRenderer).getDisplayTransformTempMatrix (__renderTransform, snapToPixel);
+			bitmapData.__fillBatchQuad (transform, __batchQuad.vertexData);
+			__batchQuad.texture = __bitmapData.__getBatcherTexture (renderSession.gl);
+			__batchQuadDirty = false;
+		}
+		
+		__batchQuad.alpha = __worldAlpha;
+		__batchQuad.colorTransform = __worldColorTransform;
+		__batchQuad.blendMode = __worldBlendMode;
+		__batchQuad.smoothing = smoothing;
+		
+		return __batchQuad;
+		
+	}
+
+	override function __updateTransforms (overrideTransform:Matrix = null):Void {
+		super.__updateTransforms (overrideTransform);
+		
+		if (overrideTransform == null) {
+			__batchQuadDirty = true;
+		}
+		
+	}
 	private override function __renderDOMClear (renderSession: RenderSession):Void {
 		
 		DOMBitmap.clear (this, renderSession);
@@ -301,6 +336,7 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 		smoothing = false;
 		
 		__setRenderDirty ();
+		__batchQuadDirty = true;
 		
 		if (__hasFilters ()) {
 			

--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -248,7 +248,7 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 			var snapToPixel = renderSession.roundPixels || __snapToPixel ();
 			var transform = (cast renderSession.renderer : GLRenderer).getDisplayTransformTempMatrix (__renderTransform, snapToPixel);
 			bitmapData.__fillBatchQuad (transform, __batchQuad.vertexData);
-			__batchQuad.texture = __bitmapData.__getBatcherTexture (renderSession.gl);
+			__batchQuad.texture = __bitmapData.__getQuadTextureData (renderSession.gl);
 			__batchQuadDirty = false;
 		}
 		

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -11,7 +11,6 @@ import lime.graphics.cairo.CairoSurface;
 import lime.graphics.cairo.Cairo;
 import lime.graphics.opengl.GLBuffer;
 import lime.graphics.opengl.GLFramebuffer;
-import lime.graphics.opengl.GLTexture;
 import lime.graphics.opengl.GLVertexArrayObject;
 import lime.graphics.opengl.GL;
 import lime.graphics.opengl.WebGLContext;
@@ -47,6 +46,8 @@ import openfl.geom.Rectangle;
 import openfl.utils.ByteArray;
 import openfl.utils.Object;
 import openfl.Vector;
+import openfl._internal.renderer.opengl.batcher.TextureData;
+import openfl._internal.renderer.opengl.batcher.Texture as BatcherTexture;
 
 #if (js && html5)
 import js.html.CanvasElement;
@@ -120,7 +121,8 @@ class BitmapData implements IBitmapDrawable {
 	private var __renderable:Bool;
 	private var __pixelRatio:Float = 1.0;
 	private var __surface:CairoSurface;
-	private var __texture:GLTexture;
+	private var __textureData:TextureData;
+	private var __batcherTexture:BatcherTexture;
 	private var __textureContext:GLRenderContext;
 	private var __textureVersion:Int;
 	private var __ownsTexture:Bool;
@@ -237,7 +239,7 @@ class BitmapData implements IBitmapDrawable {
 			
 			bitmapData.__framebuffer = __framebuffer;
 			bitmapData.__framebufferContext = __framebufferContext;
-			bitmapData.__texture = __texture;
+			bitmapData.__textureData = __textureData;
 			bitmapData.__textureContext = __textureContext;
 			bitmapData.__isValid = true;
 			
@@ -458,30 +460,10 @@ class BitmapData implements IBitmapDrawable {
 		
 		if (__ownsTexture) {
 			__ownsTexture = false;
-			__textureContext.deleteTexture (__texture);
-			__texture = null;
+			__textureContext.deleteTexture (__textureData.glTexture);
+			__textureData = null;
 			__textureContext = null;
 		}
-		
-		//if (__texture != null) {
-			//
-			//var renderer = @:privateAccess Lib.current.stage.__renderer;
-			//
-			//if(renderer != null) {
-				//
-				//var renderSession = @:privateAccess renderer.renderSession;
-				//var gl = renderSession.gl;
-				//
-				//if (gl != null) {
-					//
-					//gl.deleteTexture (__texture);
-					//__texture = null;
-					//
-				//}
-				//
-			//}
-			//
-		//}
 		
 	}
 	
@@ -850,7 +832,7 @@ class BitmapData implements IBitmapDrawable {
 		
 		var bitmapData = new BitmapData (texture.__width, texture.__height, true, 0);
 		bitmapData.readable = false;
-		bitmapData.__texture = texture.__textureID;
+		bitmapData.__textureData = new TextureData(texture.__textureID);
 		bitmapData.__textureContext = texture.__textureContext;
 		bitmapData.image = null;
 		return bitmapData;
@@ -1123,20 +1105,21 @@ class BitmapData implements IBitmapDrawable {
 		
 		return __surface;
 		
+		
 	}
 	
 	
-	public function getTexture (gl:GLRenderContext):GLTexture {
+	public function getTexture (gl:GLRenderContext):TextureData {
 		
 		if (!__isValid) return null;
 		
-		if (__texture == null || __textureContext != gl) {
+		if (__textureData == null || __textureContext != gl) {
 			
 			__textureContext = gl;
-			__texture = gl.createTexture ();
+			__textureData = new TextureData(gl.createTexture ());
 			__ownsTexture = true;
 			
-			gl.bindTexture (gl.TEXTURE_2D, __texture);
+			gl.bindTexture (gl.TEXTURE_2D, __textureData.glTexture);
 			gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
 			gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 			gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
@@ -1202,7 +1185,7 @@ class BitmapData implements IBitmapDrawable {
 				
 			}
 			
-			gl.bindTexture (gl.TEXTURE_2D, __texture);
+			gl.bindTexture (gl.TEXTURE_2D, __textureData.glTexture);
 			
 			var textureImage = image;
 			
@@ -1272,7 +1255,45 @@ class BitmapData implements IBitmapDrawable {
 			
 		}
 		
-		return __texture;
+		return __textureData;
+		
+	}
+	
+	
+	public function __getBatcherTexture (gl:GLRenderContext):BatcherTexture {
+		
+		if (__batcherTexture == null) {
+			__batcherTexture = BatcherTexture.createFullFrame (getTexture (gl));
+		}
+		
+		return __batcherTexture;
+		
+	}
+	
+	
+	function __fillBatchQuad (transform:Matrix, vertexData:Float32Array) {
+		
+		__fillTransformedVertexCoords (transform, vertexData, 0, 0, width / __pixelRatio, height / __pixelRatio);
+		
+	}
+	
+	
+	inline function __fillTransformedVertexCoords (transform:Matrix, vertexData:Float32Array, x:Float, y:Float, w:Float, h:Float) {
+		
+		var x1 = x + w;
+		var y1 = y + h;
+		
+		vertexData[0] = transform.__transformX (x, y);
+		vertexData[1] = transform.__transformY (x, y);
+		
+		vertexData[2] = transform.__transformX (x1, y);
+		vertexData[3] = transform.__transformY (x1, y);
+		
+		vertexData[4] = transform.__transformX (x1, y1);
+		vertexData[5] = transform.__transformY (x1, y1);
+		
+		vertexData[6] = transform.__transformX (x, y1);
+		vertexData[7] = transform.__transformY (x, y1);
 		
 	}
 	
@@ -1996,7 +2017,7 @@ class BitmapData implements IBitmapDrawable {
 			__framebuffer = gl.createFramebuffer ();
 			
 			gl.bindFramebuffer (gl.FRAMEBUFFER, __framebuffer);
-			gl.framebufferTexture2D (gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, __texture, 0);
+			gl.framebufferTexture2D (gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, __textureData.glTexture, 0);
 			
 		}
 		
@@ -2269,6 +2290,9 @@ class BitmapData implements IBitmapDrawable {
 	Can only be used for reading after calling `__getTextureRegion`.
 **/
 @:publicFields class TextureRegionResult {
+	/** a single helper instance that can be used for returning results that are immediately processed */
+	public static var helperInstance(default,never) = new TextureRegionResult();
+	
 	var u0:Float;
 	var v0:Float;
 	var u1:Float;

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -47,7 +47,7 @@ import openfl.utils.ByteArray;
 import openfl.utils.Object;
 import openfl.Vector;
 import openfl._internal.renderer.opengl.batcher.TextureData;
-import openfl._internal.renderer.opengl.batcher.Texture as BatcherTexture;
+import openfl._internal.renderer.opengl.batcher.QuadTextureData;
 
 #if (js && html5)
 import js.html.CanvasElement;
@@ -122,7 +122,7 @@ class BitmapData implements IBitmapDrawable {
 	private var __pixelRatio:Float = 1.0;
 	private var __surface:CairoSurface;
 	private var __textureData:TextureData;
-	private var __batcherTexture:BatcherTexture;
+	private var __quadTextureData:QuadTextureData;
 	private var __textureContext:GLRenderContext;
 	private var __textureVersion:Int;
 	private var __ownsTexture:Bool;
@@ -1260,13 +1260,13 @@ class BitmapData implements IBitmapDrawable {
 	}
 	
 	
-	public function __getBatcherTexture (gl:GLRenderContext):BatcherTexture {
+	public function __getQuadTextureData (gl:GLRenderContext):QuadTextureData {
 		
-		if (__batcherTexture == null) {
-			__batcherTexture = BatcherTexture.createFullFrame (getTexture (gl));
+		if (__quadTextureData == null) {
+			__quadTextureData = QuadTextureData.createFullFrame (getTexture (gl));
 		}
 		
-		return __batcherTexture;
+		return __quadTextureData;
 		
 	}
 	

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1194,6 +1194,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 				__cacheBitmap.__renderTransform.identity ();
 				__cacheBitmap.__renderTransform.tx = rect.x;
 				__cacheBitmap.__renderTransform.ty = rect.y;
+				__cacheBitmap.__batchQuadDirty = true;
 
 			}
 			

--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -941,7 +941,7 @@ import js.html.CanvasRenderingContext2D;
 			
 			var transform = (cast renderSession.renderer : GLRenderer).getDisplayTransformTempMatrix (__worldTransform, false);
 			__bitmap.__fillBatchQuad (transform, __batchQuad.vertexData);
-			__batchQuad.texture = __bitmap.__getBatcherTexture (renderSession.gl);
+			__batchQuad.texture = __bitmap.__getQuadTextureData (renderSession.gl);
 			__batchQuadDirty = false;
 		}
 		

--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -5,6 +5,8 @@ import lime.graphics.cairo.Cairo;
 import lime.graphics.Image;
 import openfl._internal.renderer.cairo.CairoGraphics;
 import openfl._internal.renderer.canvas.CanvasGraphics;
+import openfl._internal.renderer.opengl.GLRenderer;
+import openfl._internal.renderer.RenderSession;
 import openfl._internal.renderer.DrawCommandBuffer;
 import openfl._internal.renderer.DrawCommandReader;
 //import openfl._internal.renderer.opengl.utils.RenderTexture;
@@ -21,6 +23,8 @@ import openfl.geom.Matrix;
 import openfl.geom.Point;
 import openfl.geom.Rectangle;
 import openfl.Vector;
+
+import openfl._internal.renderer.opengl.batcher.Quad;
 
 #if (js && html5)
 import js.html.CanvasElement;
@@ -67,7 +71,9 @@ import js.html.CanvasRenderingContext2D;
 	private var __cairo:Cairo;
 	#end
 	
-	private var __bitmap:BitmapData;
+	private var __bitmap(default,set):BitmapData;
+	private var __batchQuad:Quad;
+	private var __batchQuadDirty:Bool = true;
 	
 	
 	private function new (owner:DisplayObject) {
@@ -925,6 +931,41 @@ import js.html.CanvasRenderingContext2D;
 	}
 	
 	
+	@:access(openfl.display.BitmapData.__fillBatchQuad)
+	function __getBatchQuad (renderSession:RenderSession, alpha, colorTransform, blendMode):Quad {
+		
+		if (__batchQuadDirty) {
+			if (__batchQuad == null) {
+				__batchQuad = new Quad ();
+			}
+			
+			var transform = (cast renderSession.renderer : GLRenderer).getDisplayTransformTempMatrix (__worldTransform, false);
+			__bitmap.__fillBatchQuad (transform, __batchQuad.vertexData);
+			__batchQuad.texture = __bitmap.__getBatcherTexture (renderSession.gl);
+			__batchQuadDirty = false;
+		}
+		
+		__batchQuad.alpha = alpha;
+		__batchQuad.colorTransform = colorTransform;
+		__batchQuad.blendMode = blendMode;
+		
+		return __batchQuad;
+		
+	}
+	
+	
+	function set___bitmap(value:BitmapData) {
+		
+		if (__bitmap != value) {
+			__bitmap = value;
+			__batchQuadDirty = true;
+		}
+		
+		return value;
+		
+	}
+	
+	
 	private function __update ():Void {
 		
 		if (__bounds == null || __bounds.width <= 0 || __bounds.height <= 0) return;
@@ -1030,6 +1071,8 @@ import js.html.CanvasRenderingContext2D;
 		
 		__width  = newWidth;
 		__height = newHeight;
+		
+		__batchQuadDirty = true;
 		
 	}
 	

--- a/src/openfl/display/ShaderParameter.hx
+++ b/src/openfl/display/ShaderParameter.hx
@@ -67,7 +67,7 @@ class ShaderParameterSampler extends ShaderParameterUniform {
 			return;
 			
 		gl.activeTexture (gl.TEXTURE0 + textureIndex);
-		gl.bindTexture (gl.TEXTURE_2D, input.getTexture (gl));
+		gl.bindTexture (gl.TEXTURE_2D, input.getTexture (gl).glTexture);
 		
 		if (smoothing) {
 			gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);

--- a/src/openfl/display/SubBitmapData.hx
+++ b/src/openfl/display/SubBitmapData.hx
@@ -6,7 +6,8 @@ import openfl.display.BitmapData;
 import js.Browser;
 import js.html.CanvasElement;
 import openfl._internal.renderer.RenderSession;
-import openfl._internal.renderer.opengl.batcher.Texture as BatcherTexture;
+import openfl._internal.renderer.opengl.batcher.TextureData;
+import openfl._internal.renderer.opengl.batcher.QuadTextureData;
 import openfl.geom.ColorTransform;
 import openfl.geom.Rectangle;
 import openfl.geom.Matrix;
@@ -21,7 +22,6 @@ import lime.graphics.opengl.GLBuffer;
 import lime.graphics.opengl.WebGLContext;
 import lime.graphics.utils.ImageCanvasUtil;
 import lime.utils.Float32Array;
-import openfl._internal.renderer.opengl.batcher.TextureData;
 #if (js && html5)
 import js.html.CanvasRenderingContext2D;
 #end
@@ -214,9 +214,9 @@ class SubBitmapData extends BitmapData {
 	}
 	
 	
-	override function __getBatcherTexture (gl:GLRenderContext):BatcherTexture {
+	override function __getQuadTextureData (gl:GLRenderContext):QuadTextureData {
 		
-		if (__batcherTexture == null) {
+		if (__quadTextureData == null) {
 			
 			var u0, v0, u1, v1, u2, v2, u3, v3;
 			if (__rotated) {
@@ -239,7 +239,7 @@ class SubBitmapData extends BitmapData {
 				v3 = __texY1;
 			}
 			
-			__batcherTexture = BatcherTexture.createRegion(getTexture (gl),
+			__quadTextureData = QuadTextureData.createRegion(getTexture (gl),
 				u0, v0,
 				u1, v1,
 				u2, v2,
@@ -248,7 +248,7 @@ class SubBitmapData extends BitmapData {
 			
 		}
 		
-		return __batcherTexture;
+		return __quadTextureData;
 		
 	}
 

--- a/src/openfl/display/TileArray.hx
+++ b/src/openfl/display/TileArray.hx
@@ -206,7 +206,7 @@ import openfl.Vector;
 				
 			}
 			
-			var textureRegion = new openfl.display.BitmapData.TextureRegionResult();
+			var textureRegion = openfl.display.BitmapData.TextureRegionResult.helperInstance;
 			
 			for (i in 0...__length) {
 				


### PR DESCRIPTION
This implements batched rendering for OpenFL display objects. The implementation is a bit dirty, but I tried to make it as less-intrusive as possible for now, but since we're on the verge of forking now anyway, we can refactor it together with everything else later. 

It works like this:
 - When traversing the scene for rendering, in `GLBitmap.render`/`GLShape.render` instead of doing a draw call, we batch a `Quad` object (maintained by the display object) into the `BatchRenderer` instance.
 - After traversing, we call `BatchRenderer.flush`, which will join `Quad`s that can be rendered together in groups. Each group can render multiple textures in a single drawcall (16 on my macbook and The Beast). It then iterates over these groups and draws them with a special shader that is able to select correct texture based on the id passed into the vertex buffer.
 - Sometimes, `BatchRenderer.flush` is called early to break the current batch. Currently that happens when masks are involved, because they need to change the stencil state and draw using a special mask shader. Also in `GLTilemap`, because I didn't implement quad batching for those as they will become obsolete in favor of normal display objects. 

There's a limitation: currently, bitmaps from the same texture but with different smoothing modes will be drawn with the smoothing mode set by the first bitmap. Hopefully we won't see this in practice, but technically this behaviour is of course wrong. It can be fixed by breaking the group when smoothing mode changes and/or using WebGL 2 Sampler objects (so no IE/Edge support).

In future it would be interesting to experiment with instanced rendering for this, because we could save some CPU<->GPU bandwidth by supplying data per quad instance instead of per vertex.