### PR TITLE
always call getTexture for BitmapData's to reupload images, also make…

### DIFF
--- a/src/openfl/_internal/renderer/opengl/GLRenderer.hx
+++ b/src/openfl/_internal/renderer/opengl/GLRenderer.hx
@@ -175,7 +175,7 @@ class GLRenderer extends AbstractRenderer {
 				
 				renderTargetA = BitmapData.fromTexture (stage.stage3Ds[0].context3D.createRectangleTexture (width, height, BGRA, true));
 				
-				gl.bindTexture (gl.TEXTURE_2D, renderTargetA.getTexture (gl).glTexture);
+				gl.bindTexture (gl.TEXTURE_2D, renderTargetA.getTexture (gl).data.glTexture);
 				gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
 				gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 				
@@ -185,7 +185,7 @@ class GLRenderer extends AbstractRenderer {
 				
 				renderTargetB = BitmapData.fromTexture (stage.stage3Ds[0].context3D.createRectangleTexture (width, height, BGRA, true));
 				
-				gl.bindTexture (gl.TEXTURE_2D, renderTargetB.getTexture (gl).glTexture);
+				gl.bindTexture (gl.TEXTURE_2D, renderTargetB.getTexture (gl).data.glTexture);
 				gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
 				gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 				
@@ -287,7 +287,7 @@ class GLRenderer extends AbstractRenderer {
 			
 		// 	cacheObject = BitmapData.fromTexture (stage.stage3Ds[0].context3D.createRectangleTexture (width, height, BGRA, true));
 			
-		// 	gl.bindTexture (gl.TEXTURE_2D, cacheObject.getTexture (gl).glTexture);
+		// 	gl.bindTexture (gl.TEXTURE_2D, cacheObject.getTexture (gl).data.glTexture);
 		// 	gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
 		// 	gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 			
@@ -299,7 +299,7 @@ class GLRenderer extends AbstractRenderer {
 				
 				renderTargetA = BitmapData.fromTexture (stage.stage3Ds[0].context3D.createRectangleTexture (width, height, BGRA, true));
 				
-				gl.bindTexture (gl.TEXTURE_2D, renderTargetA.getTexture (gl).glTexture);
+				gl.bindTexture (gl.TEXTURE_2D, renderTargetA.getTexture (gl).data.glTexture);
 				gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
 				gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 				
@@ -309,7 +309,7 @@ class GLRenderer extends AbstractRenderer {
 				
 				renderTargetB = BitmapData.fromTexture (stage.stage3Ds[0].context3D.createRectangleTexture (width, height, BGRA, true));
 				
-				gl.bindTexture (gl.TEXTURE_2D, renderTargetB.getTexture (gl).glTexture);
+				gl.bindTexture (gl.TEXTURE_2D, renderTargetB.getTexture (gl).data.glTexture);
 				gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
 				gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 				

--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -248,7 +248,7 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 			var snapToPixel = renderSession.roundPixels || __snapToPixel ();
 			var transform = (cast renderSession.renderer : GLRenderer).getDisplayTransformTempMatrix (__renderTransform, snapToPixel);
 			bitmapData.__fillBatchQuad (transform, __batchQuad.vertexData);
-			__batchQuad.texture = __bitmapData.__getQuadTextureData (renderSession.gl);
+			__batchQuad.texture = __bitmapData.getTexture (renderSession.gl);
 			__batchQuadDirty = false;
 		}
 		

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -1109,7 +1109,7 @@ class BitmapData implements IBitmapDrawable {
 	}
 	
 	
-	public function getTexture (gl:GLRenderContext):TextureData {
+	public function getTexture (gl:GLRenderContext):QuadTextureData {
 		
 		if (!__isValid) return null;
 		
@@ -1117,6 +1117,7 @@ class BitmapData implements IBitmapDrawable {
 			
 			__textureContext = gl;
 			__textureData = new TextureData(gl.createTexture ());
+			__quadTextureData = null;
 			__ownsTexture = true;
 			
 			gl.bindTexture (gl.TEXTURE_2D, __textureData.glTexture);
@@ -1254,19 +1255,19 @@ class BitmapData implements IBitmapDrawable {
 			image = null;
 			
 		}
+
+		if (__quadTextureData == null) {
+			__quadTextureData = __prepareQuadTextureData(__textureData);
+		}
 		
-		return __textureData;
+		return __quadTextureData;
 		
 	}
 	
 	
-	public function __getQuadTextureData (gl:GLRenderContext):QuadTextureData {
+	function __prepareQuadTextureData (texture:TextureData):QuadTextureData {
 		
-		if (__quadTextureData == null) {
-			__quadTextureData = QuadTextureData.createFullFrame (getTexture (gl));
-		}
-		
-		return __quadTextureData;
+		return QuadTextureData.createFullFrame (texture);
 		
 	}
 	

--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -941,7 +941,7 @@ import js.html.CanvasRenderingContext2D;
 			
 			var transform = (cast renderSession.renderer : GLRenderer).getDisplayTransformTempMatrix (__worldTransform, false);
 			__bitmap.__fillBatchQuad (transform, __batchQuad.vertexData);
-			__batchQuad.texture = __bitmap.__getQuadTextureData (renderSession.gl);
+			__batchQuad.texture = __bitmap.getTexture (renderSession.gl);
 			__batchQuadDirty = false;
 		}
 		

--- a/src/openfl/display/ShaderParameter.hx
+++ b/src/openfl/display/ShaderParameter.hx
@@ -67,7 +67,7 @@ class ShaderParameterSampler extends ShaderParameterUniform {
 			return;
 			
 		gl.activeTexture (gl.TEXTURE0 + textureIndex);
-		gl.bindTexture (gl.TEXTURE_2D, input.getTexture (gl).glTexture);
+		gl.bindTexture (gl.TEXTURE_2D, input.getTexture (gl).data.glTexture);
 		
 		if (smoothing) {
 			gl.texParameteri (gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);

--- a/src/openfl/display/SubBitmapData.hx
+++ b/src/openfl/display/SubBitmapData.hx
@@ -189,10 +189,6 @@ class SubBitmapData extends BitmapData {
 		}
 		
 	}
-
-	override function getTexture (gl:GLRenderContext):TextureData {
-		return __parentBitmap.getTexture (gl);
-	}
 	
 	
 	override function __fillBatchQuad (transform:Matrix, vertexData:Float32Array) {
@@ -214,41 +210,35 @@ class SubBitmapData extends BitmapData {
 	}
 	
 	
-	override function __getQuadTextureData (gl:GLRenderContext):QuadTextureData {
+	function __prepareQuadTextureData (texture:TextureData):QuadTextureData {
 		
-		if (__quadTextureData == null) {
-			
-			var u0, v0, u1, v1, u2, v2, u3, v3;
-			if (__rotated) {
-				u0 = __texX1;
-				v0 = __texY0;
-				u1 = __texX1;
-				v1 = __texY1;
-				u2 = __texX0;
-				v2 = __texY1;
-				u3 = __texX0;
-				v3 = __texY0;
-			} else {
-				u0 = __texX0;
-				v0 = __texY0;
-				u1 = __texX1;
-				v1 = __texY0;
-				u2 = __texX1;
-				v2 = __texY1;
-				u3 = __texX0;
-				v3 = __texY1;
-			}
-			
-			__quadTextureData = QuadTextureData.createRegion(getTexture (gl),
-				u0, v0,
-				u1, v1,
-				u2, v2,
-				u3, v3
-			);
-			
+		var u0, v0, u1, v1, u2, v2, u3, v3;
+		if (__rotated) {
+			u0 = __texX1;
+			v0 = __texY0;
+			u1 = __texX1;
+			v1 = __texY1;
+			u2 = __texX0;
+			v2 = __texY1;
+			u3 = __texX0;
+			v3 = __texY0;
+		} else {
+			u0 = __texX0;
+			v0 = __texY0;
+			u1 = __texX1;
+			v1 = __texY0;
+			u2 = __texX1;
+			v2 = __texY1;
+			u3 = __texX0;
+			v3 = __texY1;
 		}
 		
-		return __quadTextureData;
+		return QuadTextureData.createRegion(texture,
+			u0, v0,
+			u1, v1,
+			u2, v2,
+			u3, v3
+		);
 		
 	}
 


### PR DESCRIPTION
… it maintain and even return QuadTextureData

next step would be to cleaning up texture region handling - we can move that into a QuadTextureData method, I think