### PR TITLE
Invalidate the batch Quad on __forceRenderDirty

### DIFF
--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -325,6 +325,15 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 	}
 	
 	
+	override function __forceRenderDirty() {
+		
+		super.__forceRenderDirty ();
+		
+		__batchQuadDirty = true;
+		
+	}
+	
+	
 	// Get & Set Methods
 	
 	


### PR DESCRIPTION
So it's updated properly when we change display matrix on pixelRatio changes