### PR TITLE
encapsulate batcher Quad setup in a function so we don't forget to set its properties

### DIFF
--- a/src/openfl/_internal/renderer/opengl/batcher/Quad.hx
+++ b/src/openfl/_internal/renderer/opengl/batcher/Quad.hx
@@ -13,18 +13,25 @@ class Quad {
 	/** Link to the texture information **/
 	public var texture:QuadTextureData;
 
-	public var alpha:Float;
+	public var alpha(default,null):Float;
 
-	public var colorTransform:ColorTransform;
+	public var colorTransform(default,null):ColorTransform;
 
-	public var blendMode:BlendMode;
+	public var blendMode(default,null):BlendMode;
 
-	public var smoothing:Bool;
+	public var smoothing(default,null):Bool;
 
 	public function new() {
 		vertexData = new Float32Array(4 * 2);
 		alpha = 1;
 		smoothing = false;
+	}
+	
+	public inline function setup(alpha, colorTransform, blendMode, smoothing) {
+		this.alpha = alpha;
+		this.colorTransform = colorTransform;
+		this.blendMode = blendMode;
+		this.smoothing = smoothing;
 	}
 	
 	function cleanup() {

--- a/src/openfl/_internal/renderer/opengl/batcher/Quad.hx
+++ b/src/openfl/_internal/renderer/opengl/batcher/Quad.hx
@@ -27,6 +27,13 @@ class Quad {
 		smoothing = false;
 	}
 	
+	public inline function createColorTransform():ColorTransform {
+		if (colorTransform == null) {
+			colorTransform = new ColorTransform();
+		}
+		return colorTransform;
+	}
+	
 	public inline function setup(alpha, colorTransform, blendMode, smoothing) {
 		this.alpha = alpha;
 		this.colorTransform = colorTransform;

--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -260,10 +260,7 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 			__batchQuadDirty = false;
 		}
 		
-		__batchQuad.alpha = __worldAlpha;
-		__batchQuad.colorTransform = __worldColorTransform;
-		__batchQuad.blendMode = BatcherBlendMode.fromOpenFLBlendMode(__worldBlendMode);
-		__batchQuad.smoothing = smoothing;
+		__batchQuad.setup(__worldAlpha, __worldColorTransform, BatcherBlendMode.fromOpenFLBlendMode(__worldBlendMode), smoothing);
 		
 		return __batchQuad;
 		

--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -953,9 +953,7 @@ import js.html.CanvasRenderingContext2D;
 			__batchQuadDirty = false;
 		}
 		
-		__batchQuad.alpha = alpha;
-		__batchQuad.colorTransform = colorTransform;
-		__batchQuad.blendMode = BatcherBlendMode.fromOpenFLBlendMode(blendMode);
+		__batchQuad.setup(alpha, colorTransform, BatcherBlendMode.fromOpenFLBlendMode(blendMode), false);
 		
 		return __batchQuad;
 		


### PR DESCRIPTION
texture is still a public writable var though, because it's managed differently (set separately on invalidation)