### PR TITLE
Also handle fullscreen exit in `onWindowRestore`

### DIFF
--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -903,13 +903,7 @@ class Stage extends DisplayObjectContainer implements IModule {
 		__renderDirty = true;
 		__resize ();
 		
-		if (__wasFullscreen && !window.fullscreen) {
-			
-			__wasFullscreen = false;
-			__displayState = NORMAL;
-			__dispatchEvent (new FullScreenEvent (FullScreenEvent.FULL_SCREEN, false, false, false, true));
-			
-		}
+		__handleFullScreenRestore ();
 		
 	}
 	
@@ -918,8 +912,15 @@ class Stage extends DisplayObjectContainer implements IModule {
 		
 		if (this.window == null || this.window != window) return;
 		
-		//__broadcastEvent (new Event (Event.ACTIVATE));
-		
+		__handleFullScreenRestore ();
+	}
+	
+	inline function __handleFullScreenRestore() {
+		if (__wasFullscreen && !window.fullscreen) {
+			__wasFullscreen = false;
+			__displayState = NORMAL;
+			__dispatchEvent (new FullScreenEvent (FullScreenEvent.FULL_SCREEN, false, false, false, true));
+		}		
 	}
 	
 	


### PR DESCRIPTION
(requires https://github.com/innogames/lime/pull/17)

Some browsers (e.g. Chrome) don't fire resize event when leaving full-screen, but they do fire a proper restore event, so let's check for fullscreen restoration in both resize and restore.

I'm actually not sure if just handling `onRestore` isn't already enough, but it is also done in the [upstream OpenFL](https://github.com/openfl/openfl/blob/9f348385c654269e2983cd08194a8c4e0b1aec72/src/openfl/display/Stage.hx#L2277-L2294), so maybe there are browsers who fire resize, but not restore event? Anyway, since the `__wasFullscreen` flag is immediately set and checked there cannot be a case with double `FullScreenEvent` dispatch, so we're fine.