### PR TITLE
Fix the `force` logic in `__updateCacheBitmap`

### DIFF
--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -317,7 +317,7 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 	
 	private override function __updateCacheBitmap (renderSession:RenderSession, force:Bool):Bool {
 		
-		if (!__hasFilters () && renderSession.gl != null && __cacheBitmap == null) return false;
+		if (!force && !__hasFilters () && __cacheBitmap == null) return false;
 		return super.__updateCacheBitmap (renderSession, force);
 		
 	}

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1114,13 +1114,13 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		
 		if (__cacheBitmapRender) return false;
 		
-		if (cacheAsBitmap) {
+		if (force || cacheAsBitmap) {
 			
 			var rect = null;
 			
 			//if (!renderSession.lockTransform) __getWorldTransform ();
 			
-			var needRender = (__cacheBitmap == null || (__renderDirty && (force || (__children != null && __children.length > 0) || (__graphics!= null && __graphics.__dirty))) || opaqueBackground != __cacheBitmapBackground || !__cacheBitmapColorTransform.__equals (__worldColorTransform));
+			var needRender = (__cacheBitmap == null || (__renderDirty && ((__children != null && __children.length > 0) || (__graphics!= null && __graphics.__dirty))) || opaqueBackground != __cacheBitmapBackground || !__cacheBitmapColorTransform.__equals (__worldColorTransform));
 			var updateTransform = (needRender || !__cacheBitmap.__renderTransform.equals (__renderTransform));
 			var hasFilters = __hasFilters ();
 			var pixelRatio = renderSession.pixelRatio;

--- a/src/openfl/display/Tilemap.hx
+++ b/src/openfl/display/Tilemap.hx
@@ -453,16 +453,6 @@ class Tilemap extends #if !flash DisplayObject #else Bitmap implements IDisplayO
 	#end
 	
 	
-	#if !flash
-	private override function __updateCacheBitmap (renderSession:RenderSession, force:Bool):Bool {
-		
-		if (!__hasFilters ()) return false;
-		return super.__updateCacheBitmap (renderSession, force);
-		
-	}
-	#end
-	
-	
 	private function __updateTileArray ():Void {
 		
 		if (__tiles.length > 0) {


### PR DESCRIPTION
We want to force a cache-bitmap when rendering to canvas with non-default `colorTransform` even if the object is not `cacheAsBitmap`'d itself, because we have to render to a temporary bitmap and apply color transform to it before rendering it into a canvas, because there's no color transform functionality in HTML canvas drawing.

So the `force` is passed as `true` in these cases, but we didn't check it correctly: the flag should forcefully enable cache-as-bitmap and relevant processing, while it should NOT matter for determining if we need to re-render anything, because that is already handled by `__renderDirty` (which is also set to `true` when we change `colorTransform`).