### PR TITLE
Fix TextField bitmap caching.

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1120,7 +1120,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 			
 			//if (!renderSession.lockTransform) __getWorldTransform ();
 			
-			var needRender = (__cacheBitmap == null || (__renderDirty && ((__children != null && __children.length > 0) || (__graphics!= null && __graphics.__dirty))) || opaqueBackground != __cacheBitmapBackground || !__cacheBitmapColorTransform.__equals (__worldColorTransform));
+			var needRender = (__cacheBitmap == null || __cacheBitmapNeedsRender ());
 			var updateTransform = (needRender || !__cacheBitmap.__renderTransform.equals (__renderTransform));
 			var hasFilters = __hasFilters ();
 			var pixelRatio = renderSession.pixelRatio;
@@ -1328,6 +1328,24 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		
 		return false;
 		
+	}
+	
+	
+	private function __cacheBitmapNeedsRender ():Bool {
+		return
+			(
+				__renderDirty
+				&& 
+				(
+					(__children != null && __children.length > 0) // TODO: this is the only place we use __children in DisplayObject, we can probably move this check in a DisplayObjectContainer override along with __children
+					||
+					(__graphics != null && __graphics.__dirty) // TODO: not sure if this ever holds, because graphics dirty flag is reset before we end up here
+				)
+			)
+			||
+			opaqueBackground != __cacheBitmapBackground
+			||
+			!__cacheBitmapColorTransform.__equals (__worldColorTransform);
 	}
 	
 	

--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -1617,7 +1617,7 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 	
 	private override function __updateCacheBitmap (renderSession:RenderSession, force:Bool):Bool {
 		
-		var success = super.__updateCacheBitmap (renderSession, __forceCachedBitmapUpdate || force);
+		var success = super.__updateCacheBitmap (renderSession, force);
 		__forceCachedBitmapUpdate = false;
 		
 		if (success) {
@@ -1635,6 +1635,11 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 		
 		return false;
 		
+	}
+	
+	
+	override private function __cacheBitmapNeedsRender ():Bool {
+		return __forceCachedBitmapUpdate || super.__cacheBitmapNeedsRender ();
 	}
 	
 	


### PR DESCRIPTION
Since we changed the meaning of the "force" flag in #107, the value passed in the TextField override became incorrect: it SHOULD NOT force the bitmap caching, but it SHOULD force the re-render if there is bitmap caching. Basically, it's just another dirty flag. And since it's only available in TextField, we gotta use a virtual method to determine the need for a re-render so we can override it in TextField and honor its additional flag.

Also added some TODOs to look into at some point.