### PR TITLE
Fix @:to methods for OpenFL abstracts

### DIFF
--- a/lib/openfl/desktop/ClipboardFormats.hx
+++ b/lib/openfl/desktop/ClipboardFormats.hx
@@ -20,9 +20,9 @@ package openfl.desktop; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case ClipboardFormats.HTML_FORMAT: "air:html";
 			case ClipboardFormats.RICH_TEXT_FORMAT: "air:rtf";

--- a/lib/openfl/desktop/ClipboardTransferMode.hx
+++ b/lib/openfl/desktop/ClipboardTransferMode.hx
@@ -22,9 +22,9 @@ package openfl.desktop; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case ClipboardTransferMode.CLONE_ONLY: "cloneOnly";
 			case ClipboardTransferMode.CLONE_PREFERRED: "clonePreferred";

--- a/lib/openfl/display/BlendMode.hx
+++ b/lib/openfl/display/BlendMode.hx
@@ -195,9 +195,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case BlendMode.ADD: "add";
 			case BlendMode.ALPHA: "alpha";

--- a/lib/openfl/display/CapsStyle.hx
+++ b/lib/openfl/display/CapsStyle.hx
@@ -41,9 +41,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case CapsStyle.NONE: "none";
 			case CapsStyle.ROUND: "round";

--- a/lib/openfl/display/GradientType.hx
+++ b/lib/openfl/display/GradientType.hx
@@ -31,9 +31,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case GradientType.LINEAR: "linear";
 			case GradientType.RADIAL: "radial";

--- a/lib/openfl/display/GraphicsPathWinding.hx
+++ b/lib/openfl/display/GraphicsPathWinding.hx
@@ -28,9 +28,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case GraphicsPathWinding.EVEN_ODD: "evenOdd";
 			case GraphicsPathWinding.NON_ZERO: "nonZero";

--- a/lib/openfl/display/InterpolationMethod.hx
+++ b/lib/openfl/display/InterpolationMethod.hx
@@ -50,9 +50,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case InterpolationMethod.LINEAR_RGB: "linearRGB";
 			case InterpolationMethod.RGB: "rgb";

--- a/lib/openfl/display/JointStyle.hx
+++ b/lib/openfl/display/JointStyle.hx
@@ -42,9 +42,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case JointStyle.BEVEL: "bevel";
 			case JointStyle.MITER: "miter";

--- a/lib/openfl/display/LineScaleMode.hx
+++ b/lib/openfl/display/LineScaleMode.hx
@@ -56,9 +56,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case LineScaleMode.HORIZONTAL: "horizontal";
 			case LineScaleMode.NONE: "none";

--- a/lib/openfl/display/PixelSnapping.hx
+++ b/lib/openfl/display/PixelSnapping.hx
@@ -45,9 +45,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case PixelSnapping.ALWAYS: "always";
 			case PixelSnapping.AUTO: "auto";

--- a/lib/openfl/display/ShaderParameterType.hx
+++ b/lib/openfl/display/ShaderParameterType.hx
@@ -56,9 +56,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case ShaderParameterType.BOOL: "bool";
 			case ShaderParameterType.BOOL2: "bool2";

--- a/lib/openfl/display/ShaderPrecision.hx
+++ b/lib/openfl/display/ShaderPrecision.hx
@@ -18,9 +18,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case ShaderPrecision.FULL: "full";
 			case ShaderPrecision.FAST: "fast";

--- a/lib/openfl/display/SpreadMethod.hx
+++ b/lib/openfl/display/SpreadMethod.hx
@@ -39,9 +39,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case SpreadMethod.PAD: "pad";
 			case SpreadMethod.REFLECT: "reflect";

--- a/lib/openfl/display/StageAlign.hx
+++ b/lib/openfl/display/StageAlign.hx
@@ -65,9 +65,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case StageAlign.BOTTOM: "bottom";
 			case StageAlign.BOTTOM_LEFT: "bottomLeft";

--- a/lib/openfl/display/StageDisplayState.hx
+++ b/lib/openfl/display/StageDisplayState.hx
@@ -35,9 +35,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case StageDisplayState.FULL_SCREEN: "fullScreen";
 			case StageDisplayState.FULL_SCREEN_INTERACTIVE: "fullScreenInteractive";

--- a/lib/openfl/display/StageQuality.hx
+++ b/lib/openfl/display/StageQuality.hx
@@ -46,9 +46,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case StageQuality.BEST: "best";
 			case StageQuality.HIGH: "high";

--- a/lib/openfl/display/StageScaleMode.hx
+++ b/lib/openfl/display/StageScaleMode.hx
@@ -26,9 +26,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case StageScaleMode.EXACT_FIT: "exactFit";
 			case StageScaleMode.NO_BORDER: "noBorder";

--- a/lib/openfl/display/TriangleCulling.hx
+++ b/lib/openfl/display/TriangleCulling.hx
@@ -53,9 +53,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case TriangleCulling.NEGATIVE: "negative";
 			case TriangleCulling.NONE: "none";

--- a/lib/openfl/display3D/Context3DBlendFactor.hx
+++ b/lib/openfl/display3D/Context3DBlendFactor.hx
@@ -34,9 +34,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DBlendFactor.DESTINATION_ALPHA: "destinationAlpha";
 			case Context3DBlendFactor.DESTINATION_COLOR: "destinationColor";

--- a/lib/openfl/display3D/Context3DBufferUsage.hx
+++ b/lib/openfl/display3D/Context3DBufferUsage.hx
@@ -18,9 +18,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DBufferUsage.DYNAMIC_DRAW: "dynamicDraw";
 			case Context3DBufferUsage.STATIC_DRAW: "staticDraw";

--- a/lib/openfl/display3D/Context3DCompareMode.hx
+++ b/lib/openfl/display3D/Context3DCompareMode.hx
@@ -30,9 +30,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DCompareMode.ALWAYS: "always";
 			case Context3DCompareMode.EQUAL: "equal";

--- a/lib/openfl/display3D/Context3DMipFilter.hx
+++ b/lib/openfl/display3D/Context3DMipFilter.hx
@@ -20,9 +20,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DMipFilter.MIPLINEAR: "miplinear";
 			case Context3DMipFilter.MIPNEAREST: "mipnearest";

--- a/lib/openfl/display3D/Context3DProfile.hx
+++ b/lib/openfl/display3D/Context3DProfile.hx
@@ -26,9 +26,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DProfile.BASELINE: "baseline";
 			case Context3DProfile.BASELINE_CONSTRAINED: "baselineConstrained";

--- a/lib/openfl/display3D/Context3DProgramType.hx
+++ b/lib/openfl/display3D/Context3DProgramType.hx
@@ -18,9 +18,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DProgramType.FRAGMENT: "fragment";
 			case Context3DProgramType.VERTEX: "vertex";

--- a/lib/openfl/display3D/Context3DRenderMode.hx
+++ b/lib/openfl/display3D/Context3DRenderMode.hx
@@ -18,9 +18,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DRenderMode.AUTO: "auto";
 			case Context3DRenderMode.SOFTWARE: "software";

--- a/lib/openfl/display3D/Context3DStencilAction.hx
+++ b/lib/openfl/display3D/Context3DStencilAction.hx
@@ -30,9 +30,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DStencilAction.DECREMENT_SATURATE: "decrementSaturate";
 			case Context3DStencilAction.DECREMENT_WRAP: "decrementWrap";

--- a/lib/openfl/display3D/Context3DTextureFilter.hx
+++ b/lib/openfl/display3D/Context3DTextureFilter.hx
@@ -26,9 +26,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DTextureFilter.ANISOTROPIC16X: "anisotropic16x";
 			case Context3DTextureFilter.ANISOTROPIC2X: "anisotropic2x";

--- a/lib/openfl/display3D/Context3DTextureFormat.hx
+++ b/lib/openfl/display3D/Context3DTextureFormat.hx
@@ -26,9 +26,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DTextureFormat.BGR_PACKED: "bgrPacked565";
 			case Context3DTextureFormat.BGRA: "bgra";

--- a/lib/openfl/display3D/Context3DTriangleFace.hx
+++ b/lib/openfl/display3D/Context3DTriangleFace.hx
@@ -22,9 +22,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DTriangleFace.BACK: "back";
 			case Context3DTriangleFace.FRONT: "front";

--- a/lib/openfl/display3D/Context3DVertexBufferFormat.hx
+++ b/lib/openfl/display3D/Context3DVertexBufferFormat.hx
@@ -24,9 +24,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DVertexBufferFormat.BYTES_4: "bytes4";
 			case Context3DVertexBufferFormat.FLOAT_1: "float1";

--- a/lib/openfl/display3D/Context3DWrapMode.hx
+++ b/lib/openfl/display3D/Context3DWrapMode.hx
@@ -22,9 +22,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DWrapMode.CLAMP: "clamp";
 			case Context3DWrapMode.CLAMP_U_REPEAT_V: "clamp_u_repeat_y";

--- a/lib/openfl/filters/BitmapFilterType.hx
+++ b/lib/openfl/filters/BitmapFilterType.hx
@@ -35,9 +35,9 @@ package openfl.filters; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case BitmapFilterType.FULL: "full";
 			case BitmapFilterType.INNER: "inner";

--- a/lib/openfl/geom/Orientation3D.hx
+++ b/lib/openfl/geom/Orientation3D.hx
@@ -20,9 +20,9 @@ package openfl.geom; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Orientation3D.AXIS_ANGLE: "axisAngle";
 			case Orientation3D.EULER_ANGLES: "eulerAngles";

--- a/lib/openfl/net/SharedObjectFlushStatus.hx
+++ b/lib/openfl/net/SharedObjectFlushStatus.hx
@@ -30,9 +30,9 @@ package openfl.net; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case SharedObjectFlushStatus.FLUSHED: "flushed";
 			case SharedObjectFlushStatus.PENDING: "pending";

--- a/lib/openfl/net/URLLoaderDataFormat.hx
+++ b/lib/openfl/net/URLLoaderDataFormat.hx
@@ -35,9 +35,9 @@ package openfl.net; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case URLLoaderDataFormat.BINARY: "binary";
 			case URLLoaderDataFormat.TEXT: "text";

--- a/lib/openfl/printing/PrintJobOrientation.hx
+++ b/lib/openfl/printing/PrintJobOrientation.hx
@@ -18,9 +18,9 @@ package openfl.printing; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case PrintJobOrientation.LANDSCAPE: "landscape";
 			case PrintJobOrientation.PORTRAIT: "portrait";

--- a/lib/openfl/system/TouchscreenType.hx
+++ b/lib/openfl/system/TouchscreenType.hx
@@ -20,9 +20,9 @@ package openfl.system; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case TouchscreenType.FINGER: "finger";
 			case TouchscreenType.NONE: "none";

--- a/lib/openfl/text/AntiAliasType.hx
+++ b/lib/openfl/text/AntiAliasType.hx
@@ -39,9 +39,9 @@ package openfl.text; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case AntiAliasType.ADVANCED: "advanced";
 			case AntiAliasType.NORMAL: "normal";

--- a/lib/openfl/text/FontStyle.hx
+++ b/lib/openfl/text/FontStyle.hx
@@ -48,9 +48,9 @@ package openfl.text; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case FontStyle.BOLD: "bold";
 			case FontStyle.BOLD_ITALIC: "boldItalic";

--- a/lib/openfl/text/FontType.hx
+++ b/lib/openfl/text/FontType.hx
@@ -59,9 +59,9 @@ package openfl.text; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case FontType.DEVICE: "device";
 			case FontType.EMBEDDED: "embedded";

--- a/lib/openfl/text/GridFitType.hx
+++ b/lib/openfl/text/GridFitType.hx
@@ -20,9 +20,9 @@ package openfl.text; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case GridFitType.NONE: "none";
 			case GridFitType.PIXEL: "pixel";

--- a/lib/openfl/text/TextFieldAutoSize.hx
+++ b/lib/openfl/text/TextFieldAutoSize.hx
@@ -47,9 +47,9 @@ package openfl.text; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case TextFieldAutoSize.CENTER: "center";
 			case TextFieldAutoSize.LEFT: "left";

--- a/lib/openfl/text/TextFieldType.hx
+++ b/lib/openfl/text/TextFieldType.hx
@@ -29,9 +29,9 @@ package openfl.text; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case TextFieldType.DYNAMIC: "dynamic";
 			case TextFieldType.INPUT: "input";

--- a/lib/openfl/text/TextFormatAlign.hx
+++ b/lib/openfl/text/TextFormatAlign.hx
@@ -51,9 +51,9 @@ package openfl.text; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case TextFormatAlign.CENTER: "center";
 			case TextFormatAlign.END: "end";

--- a/lib/openfl/ui/MultitouchInputMode.hx
+++ b/lib/openfl/ui/MultitouchInputMode.hx
@@ -38,9 +38,9 @@ package openfl.ui; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case MultitouchInputMode.GESTURE: "gesture";
 			case MultitouchInputMode.NONE: "none";

--- a/lib/openfl/utils/CompressionAlgorithm.hx
+++ b/lib/openfl/utils/CompressionAlgorithm.hx
@@ -21,9 +21,9 @@ package openfl.utils; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case CompressionAlgorithm.DEFLATE: "deflate";
 			case CompressionAlgorithm.LZMA: "lzma";

--- a/lib/openfl/utils/Endian.hx
+++ b/lib/openfl/utils/Endian.hx
@@ -51,9 +51,9 @@ package openfl.utils; #if (display || !flash)
 	}
 	
 	
-	// @:to private static function toLimeEndian (value:Int):LimeEndian {
+	// @:to private function toLimeEndian ():LimeEndian {
 		
-	// 	return switch (value) {
+	// 	return switch (cast this) {
 			
 	// 		case Endian.BIG_ENDIAN: LimeEndian.BIG_ENDIAN;
 	// 		case Endian.LITTLE_ENDIAN: LimeEndian.LITTLE_ENDIAN;
@@ -64,9 +64,9 @@ package openfl.utils; #if (display || !flash)
 	// }
 	
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Endian.BIG_ENDIAN: "bigEndian";
 			case Endian.LITTLE_ENDIAN: "littleEndian";

--- a/src/externs/core/flash/flash/utils/Endian.hx
+++ b/src/externs/core/flash/flash/utils/Endian.hx
@@ -23,9 +23,9 @@ import lime.system.Endian in LimeEndian;
 	}
 	
 	
-	@:to private static function toLimeEndian (value:String):LimeEndian {
+	@:to private function toLimeEndian ():LimeEndian {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Endian.BIG_ENDIAN: LimeEndian.BIG_ENDIAN;
 			case Endian.LITTLE_ENDIAN: LimeEndian.LITTLE_ENDIAN;

--- a/src/externs/core/openfl/openfl/desktop/ClipboardFormats.hx
+++ b/src/externs/core/openfl/openfl/desktop/ClipboardFormats.hx
@@ -20,9 +20,9 @@ package openfl.desktop; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case ClipboardFormats.HTML_FORMAT: "air:html";
 			case ClipboardFormats.RICH_TEXT_FORMAT: "air:rtf";

--- a/src/externs/core/openfl/openfl/desktop/ClipboardTransferMode.hx
+++ b/src/externs/core/openfl/openfl/desktop/ClipboardTransferMode.hx
@@ -22,9 +22,9 @@ package openfl.desktop; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case ClipboardTransferMode.CLONE_ONLY: "cloneOnly";
 			case ClipboardTransferMode.CLONE_PREFERRED: "clonePreferred";

--- a/src/externs/core/openfl/openfl/display/BlendMode.hx
+++ b/src/externs/core/openfl/openfl/display/BlendMode.hx
@@ -195,9 +195,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case BlendMode.ADD: "add";
 			case BlendMode.ALPHA: "alpha";

--- a/src/externs/core/openfl/openfl/display/CapsStyle.hx
+++ b/src/externs/core/openfl/openfl/display/CapsStyle.hx
@@ -41,9 +41,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case CapsStyle.NONE: "none";
 			case CapsStyle.ROUND: "round";

--- a/src/externs/core/openfl/openfl/display/GradientType.hx
+++ b/src/externs/core/openfl/openfl/display/GradientType.hx
@@ -31,9 +31,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case GradientType.LINEAR: "linear";
 			case GradientType.RADIAL: "radial";

--- a/src/externs/core/openfl/openfl/display/GraphicsPathWinding.hx
+++ b/src/externs/core/openfl/openfl/display/GraphicsPathWinding.hx
@@ -28,9 +28,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case GraphicsPathWinding.EVEN_ODD: "evenOdd";
 			case GraphicsPathWinding.NON_ZERO: "nonZero";

--- a/src/externs/core/openfl/openfl/display/InterpolationMethod.hx
+++ b/src/externs/core/openfl/openfl/display/InterpolationMethod.hx
@@ -50,9 +50,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case InterpolationMethod.LINEAR_RGB: "linearRGB";
 			case InterpolationMethod.RGB: "rgb";

--- a/src/externs/core/openfl/openfl/display/JointStyle.hx
+++ b/src/externs/core/openfl/openfl/display/JointStyle.hx
@@ -42,9 +42,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case JointStyle.BEVEL: "bevel";
 			case JointStyle.MITER: "miter";

--- a/src/externs/core/openfl/openfl/display/LineScaleMode.hx
+++ b/src/externs/core/openfl/openfl/display/LineScaleMode.hx
@@ -56,9 +56,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case LineScaleMode.HORIZONTAL: "horizontal";
 			case LineScaleMode.NONE: "none";

--- a/src/externs/core/openfl/openfl/display/PixelSnapping.hx
+++ b/src/externs/core/openfl/openfl/display/PixelSnapping.hx
@@ -45,9 +45,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case PixelSnapping.ALWAYS: "always";
 			case PixelSnapping.AUTO: "auto";

--- a/src/externs/core/openfl/openfl/display/ShaderParameterType.hx
+++ b/src/externs/core/openfl/openfl/display/ShaderParameterType.hx
@@ -56,9 +56,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case ShaderParameterType.BOOL: "bool";
 			case ShaderParameterType.BOOL2: "bool2";

--- a/src/externs/core/openfl/openfl/display/ShaderPrecision.hx
+++ b/src/externs/core/openfl/openfl/display/ShaderPrecision.hx
@@ -18,9 +18,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case ShaderPrecision.FULL: "full";
 			case ShaderPrecision.FAST: "fast";

--- a/src/externs/core/openfl/openfl/display/SpreadMethod.hx
+++ b/src/externs/core/openfl/openfl/display/SpreadMethod.hx
@@ -39,9 +39,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case SpreadMethod.PAD: "pad";
 			case SpreadMethod.REFLECT: "reflect";

--- a/src/externs/core/openfl/openfl/display/StageAlign.hx
+++ b/src/externs/core/openfl/openfl/display/StageAlign.hx
@@ -65,9 +65,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case StageAlign.BOTTOM: "bottom";
 			case StageAlign.BOTTOM_LEFT: "bottomLeft";

--- a/src/externs/core/openfl/openfl/display/StageDisplayState.hx
+++ b/src/externs/core/openfl/openfl/display/StageDisplayState.hx
@@ -35,9 +35,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case StageDisplayState.FULL_SCREEN: "fullScreen";
 			case StageDisplayState.FULL_SCREEN_INTERACTIVE: "fullScreenInteractive";

--- a/src/externs/core/openfl/openfl/display/StageQuality.hx
+++ b/src/externs/core/openfl/openfl/display/StageQuality.hx
@@ -46,9 +46,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case StageQuality.BEST: "best";
 			case StageQuality.HIGH: "high";

--- a/src/externs/core/openfl/openfl/display/StageScaleMode.hx
+++ b/src/externs/core/openfl/openfl/display/StageScaleMode.hx
@@ -26,9 +26,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case StageScaleMode.EXACT_FIT: "exactFit";
 			case StageScaleMode.NO_BORDER: "noBorder";

--- a/src/externs/core/openfl/openfl/display/TriangleCulling.hx
+++ b/src/externs/core/openfl/openfl/display/TriangleCulling.hx
@@ -53,9 +53,9 @@ package openfl.display; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case TriangleCulling.NEGATIVE: "negative";
 			case TriangleCulling.NONE: "none";

--- a/src/externs/core/openfl/openfl/display3D/Context3DBlendFactor.hx
+++ b/src/externs/core/openfl/openfl/display3D/Context3DBlendFactor.hx
@@ -34,9 +34,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DBlendFactor.DESTINATION_ALPHA: "destinationAlpha";
 			case Context3DBlendFactor.DESTINATION_COLOR: "destinationColor";

--- a/src/externs/core/openfl/openfl/display3D/Context3DBufferUsage.hx
+++ b/src/externs/core/openfl/openfl/display3D/Context3DBufferUsage.hx
@@ -18,9 +18,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DBufferUsage.DYNAMIC_DRAW: "dynamicDraw";
 			case Context3DBufferUsage.STATIC_DRAW: "staticDraw";

--- a/src/externs/core/openfl/openfl/display3D/Context3DCompareMode.hx
+++ b/src/externs/core/openfl/openfl/display3D/Context3DCompareMode.hx
@@ -30,9 +30,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DCompareMode.ALWAYS: "always";
 			case Context3DCompareMode.EQUAL: "equal";

--- a/src/externs/core/openfl/openfl/display3D/Context3DMipFilter.hx
+++ b/src/externs/core/openfl/openfl/display3D/Context3DMipFilter.hx
@@ -20,9 +20,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DMipFilter.MIPLINEAR: "miplinear";
 			case Context3DMipFilter.MIPNEAREST: "mipnearest";

--- a/src/externs/core/openfl/openfl/display3D/Context3DProfile.hx
+++ b/src/externs/core/openfl/openfl/display3D/Context3DProfile.hx
@@ -26,9 +26,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DProfile.BASELINE: "baseline";
 			case Context3DProfile.BASELINE_CONSTRAINED: "baselineConstrained";

--- a/src/externs/core/openfl/openfl/display3D/Context3DProgramType.hx
+++ b/src/externs/core/openfl/openfl/display3D/Context3DProgramType.hx
@@ -18,9 +18,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DProgramType.FRAGMENT: "fragment";
 			case Context3DProgramType.VERTEX: "vertex";

--- a/src/externs/core/openfl/openfl/display3D/Context3DRenderMode.hx
+++ b/src/externs/core/openfl/openfl/display3D/Context3DRenderMode.hx
@@ -18,9 +18,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DRenderMode.AUTO: "auto";
 			case Context3DRenderMode.SOFTWARE: "software";

--- a/src/externs/core/openfl/openfl/display3D/Context3DStencilAction.hx
+++ b/src/externs/core/openfl/openfl/display3D/Context3DStencilAction.hx
@@ -30,9 +30,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DStencilAction.DECREMENT_SATURATE: "decrementSaturate";
 			case Context3DStencilAction.DECREMENT_WRAP: "decrementWrap";

--- a/src/externs/core/openfl/openfl/display3D/Context3DTextureFilter.hx
+++ b/src/externs/core/openfl/openfl/display3D/Context3DTextureFilter.hx
@@ -26,9 +26,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DTextureFilter.ANISOTROPIC16X: "anisotropic16x";
 			case Context3DTextureFilter.ANISOTROPIC2X: "anisotropic2x";

--- a/src/externs/core/openfl/openfl/display3D/Context3DTextureFormat.hx
+++ b/src/externs/core/openfl/openfl/display3D/Context3DTextureFormat.hx
@@ -26,9 +26,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DTextureFormat.BGR_PACKED: "bgrPacked565";
 			case Context3DTextureFormat.BGRA: "bgra";

--- a/src/externs/core/openfl/openfl/display3D/Context3DTriangleFace.hx
+++ b/src/externs/core/openfl/openfl/display3D/Context3DTriangleFace.hx
@@ -22,9 +22,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DTriangleFace.BACK: "back";
 			case Context3DTriangleFace.FRONT: "front";

--- a/src/externs/core/openfl/openfl/display3D/Context3DVertexBufferFormat.hx
+++ b/src/externs/core/openfl/openfl/display3D/Context3DVertexBufferFormat.hx
@@ -24,9 +24,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DVertexBufferFormat.BYTES_4: "bytes4";
 			case Context3DVertexBufferFormat.FLOAT_1: "float1";

--- a/src/externs/core/openfl/openfl/display3D/Context3DWrapMode.hx
+++ b/src/externs/core/openfl/openfl/display3D/Context3DWrapMode.hx
@@ -22,9 +22,9 @@ package openfl.display3D; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DWrapMode.CLAMP: "clamp";
 			case Context3DWrapMode.CLAMP_U_REPEAT_V: "clamp_u_repeat_y";

--- a/src/externs/core/openfl/openfl/filters/BitmapFilterType.hx
+++ b/src/externs/core/openfl/openfl/filters/BitmapFilterType.hx
@@ -35,9 +35,9 @@ package openfl.filters; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case BitmapFilterType.FULL: "full";
 			case BitmapFilterType.INNER: "inner";

--- a/src/externs/core/openfl/openfl/geom/Orientation3D.hx
+++ b/src/externs/core/openfl/openfl/geom/Orientation3D.hx
@@ -20,9 +20,9 @@ package openfl.geom; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Orientation3D.AXIS_ANGLE: "axisAngle";
 			case Orientation3D.EULER_ANGLES: "eulerAngles";

--- a/src/externs/core/openfl/openfl/net/SharedObjectFlushStatus.hx
+++ b/src/externs/core/openfl/openfl/net/SharedObjectFlushStatus.hx
@@ -30,9 +30,9 @@ package openfl.net; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case SharedObjectFlushStatus.FLUSHED: "flushed";
 			case SharedObjectFlushStatus.PENDING: "pending";

--- a/src/externs/core/openfl/openfl/net/URLLoaderDataFormat.hx
+++ b/src/externs/core/openfl/openfl/net/URLLoaderDataFormat.hx
@@ -35,9 +35,9 @@ package openfl.net; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case URLLoaderDataFormat.BINARY: "binary";
 			case URLLoaderDataFormat.TEXT: "text";

--- a/src/externs/core/openfl/openfl/printing/PrintJobOrientation.hx
+++ b/src/externs/core/openfl/openfl/printing/PrintJobOrientation.hx
@@ -18,9 +18,9 @@ package openfl.printing; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case PrintJobOrientation.LANDSCAPE: "landscape";
 			case PrintJobOrientation.PORTRAIT: "portrait";

--- a/src/externs/core/openfl/openfl/system/TouchscreenType.hx
+++ b/src/externs/core/openfl/openfl/system/TouchscreenType.hx
@@ -20,9 +20,9 @@ package openfl.system; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case TouchscreenType.FINGER: "finger";
 			case TouchscreenType.NONE: "none";

--- a/src/externs/core/openfl/openfl/text/AntiAliasType.hx
+++ b/src/externs/core/openfl/openfl/text/AntiAliasType.hx
@@ -39,9 +39,9 @@ package openfl.text; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case AntiAliasType.ADVANCED: "advanced";
 			case AntiAliasType.NORMAL: "normal";

--- a/src/externs/core/openfl/openfl/text/FontStyle.hx
+++ b/src/externs/core/openfl/openfl/text/FontStyle.hx
@@ -48,9 +48,9 @@ package openfl.text; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case FontStyle.BOLD: "bold";
 			case FontStyle.BOLD_ITALIC: "boldItalic";

--- a/src/externs/core/openfl/openfl/text/FontType.hx
+++ b/src/externs/core/openfl/openfl/text/FontType.hx
@@ -59,9 +59,9 @@ package openfl.text; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case FontType.DEVICE: "device";
 			case FontType.EMBEDDED: "embedded";

--- a/src/externs/core/openfl/openfl/text/GridFitType.hx
+++ b/src/externs/core/openfl/openfl/text/GridFitType.hx
@@ -20,9 +20,9 @@ package openfl.text; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case GridFitType.NONE: "none";
 			case GridFitType.PIXEL: "pixel";

--- a/src/externs/core/openfl/openfl/text/TextFieldAutoSize.hx
+++ b/src/externs/core/openfl/openfl/text/TextFieldAutoSize.hx
@@ -47,9 +47,9 @@ package openfl.text; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case TextFieldAutoSize.CENTER: "center";
 			case TextFieldAutoSize.LEFT: "left";

--- a/src/externs/core/openfl/openfl/text/TextFieldType.hx
+++ b/src/externs/core/openfl/openfl/text/TextFieldType.hx
@@ -29,9 +29,9 @@ package openfl.text; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case TextFieldType.DYNAMIC: "dynamic";
 			case TextFieldType.INPUT: "input";

--- a/src/externs/core/openfl/openfl/text/TextFormatAlign.hx
+++ b/src/externs/core/openfl/openfl/text/TextFormatAlign.hx
@@ -51,9 +51,9 @@ package openfl.text; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case TextFormatAlign.CENTER: "center";
 			case TextFormatAlign.END: "end";

--- a/src/externs/core/openfl/openfl/ui/MultitouchInputMode.hx
+++ b/src/externs/core/openfl/openfl/ui/MultitouchInputMode.hx
@@ -38,9 +38,9 @@ package openfl.ui; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case MultitouchInputMode.GESTURE: "gesture";
 			case MultitouchInputMode.NONE: "none";

--- a/src/externs/core/openfl/openfl/utils/CompressionAlgorithm.hx
+++ b/src/externs/core/openfl/openfl/utils/CompressionAlgorithm.hx
@@ -21,9 +21,9 @@ package openfl.utils; #if (display || !flash)
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case CompressionAlgorithm.DEFLATE: "deflate";
 			case CompressionAlgorithm.LZMA: "lzma";

--- a/src/externs/core/openfl/openfl/utils/Endian.hx
+++ b/src/externs/core/openfl/openfl/utils/Endian.hx
@@ -51,9 +51,9 @@ import lime.system.Endian in LimeEndian;
 	}
 	
 	
-	@:to private static function toLimeEndian (value:Int):LimeEndian {
+	@:to private function toLimeEndian ():LimeEndian {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Endian.BIG_ENDIAN: LimeEndian.BIG_ENDIAN;
 			case Endian.LITTLE_ENDIAN: LimeEndian.LITTLE_ENDIAN;
@@ -64,9 +64,9 @@ import lime.system.Endian in LimeEndian;
 	}
 	
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Endian.BIG_ENDIAN: "bigEndian";
 			case Endian.LITTLE_ENDIAN: "littleEndian";

--- a/src/openfl/desktop/ClipboardFormats.hx
+++ b/src/openfl/desktop/ClipboardFormats.hx
@@ -20,9 +20,9 @@ package openfl.desktop;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case ClipboardFormats.HTML_FORMAT: "air:html";
 			case ClipboardFormats.RICH_TEXT_FORMAT: "air:rtf";

--- a/src/openfl/desktop/ClipboardTransferMode.hx
+++ b/src/openfl/desktop/ClipboardTransferMode.hx
@@ -22,9 +22,9 @@ package openfl.desktop;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case ClipboardTransferMode.CLONE_ONLY: "cloneOnly";
 			case ClipboardTransferMode.CLONE_PREFERRED: "clonePreferred";

--- a/src/openfl/display/BlendMode.hx
+++ b/src/openfl/display/BlendMode.hx
@@ -44,9 +44,9 @@ package openfl.display;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case BlendMode.ADD: "add";
 			case BlendMode.ALPHA: "alpha";

--- a/src/openfl/display/CapsStyle.hx
+++ b/src/openfl/display/CapsStyle.hx
@@ -20,9 +20,9 @@ package openfl.display;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case CapsStyle.NONE: "none";
 			case CapsStyle.ROUND: "round";

--- a/src/openfl/display/GradientType.hx
+++ b/src/openfl/display/GradientType.hx
@@ -18,9 +18,9 @@ package openfl.display;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case GradientType.LINEAR: "linear";
 			case GradientType.RADIAL: "radial";

--- a/src/openfl/display/GraphicsPathWinding.hx
+++ b/src/openfl/display/GraphicsPathWinding.hx
@@ -18,9 +18,9 @@ package openfl.display;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case GraphicsPathWinding.EVEN_ODD: "evenOdd";
 			case GraphicsPathWinding.NON_ZERO: "nonZero";

--- a/src/openfl/display/InterpolationMethod.hx
+++ b/src/openfl/display/InterpolationMethod.hx
@@ -18,9 +18,9 @@ package openfl.display;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case InterpolationMethod.LINEAR_RGB: "linearRGB";
 			case InterpolationMethod.RGB: "rgb";

--- a/src/openfl/display/JointStyle.hx
+++ b/src/openfl/display/JointStyle.hx
@@ -20,9 +20,9 @@ package openfl.display;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case JointStyle.BEVEL: "bevel";
 			case JointStyle.MITER: "miter";

--- a/src/openfl/display/LineScaleMode.hx
+++ b/src/openfl/display/LineScaleMode.hx
@@ -22,9 +22,9 @@ package openfl.display;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case LineScaleMode.HORIZONTAL: "horizontal";
 			case LineScaleMode.NONE: "none";

--- a/src/openfl/display/PixelSnapping.hx
+++ b/src/openfl/display/PixelSnapping.hx
@@ -20,9 +20,9 @@ package openfl.display;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case PixelSnapping.ALWAYS: "always";
 			case PixelSnapping.AUTO: "auto";

--- a/src/openfl/display/ShaderPrecision.hx
+++ b/src/openfl/display/ShaderPrecision.hx
@@ -18,9 +18,9 @@ package openfl.display;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case ShaderPrecision.FULL: "full";
 			case ShaderPrecision.FAST: "fast";

--- a/src/openfl/display/SpreadMethod.hx
+++ b/src/openfl/display/SpreadMethod.hx
@@ -20,9 +20,9 @@ package openfl.display;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case SpreadMethod.PAD: "pad";
 			case SpreadMethod.REFLECT: "reflect";

--- a/src/openfl/display/StageAlign.hx
+++ b/src/openfl/display/StageAlign.hx
@@ -30,9 +30,9 @@ package openfl.display;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case StageAlign.BOTTOM: "bottom";
 			case StageAlign.BOTTOM_LEFT: "bottomLeft";

--- a/src/openfl/display/StageDisplayState.hx
+++ b/src/openfl/display/StageDisplayState.hx
@@ -20,9 +20,9 @@ package openfl.display;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case StageDisplayState.FULL_SCREEN: "fullScreen";
 			case StageDisplayState.FULL_SCREEN_INTERACTIVE: "fullScreenInteractive";

--- a/src/openfl/display/StageQuality.hx
+++ b/src/openfl/display/StageQuality.hx
@@ -22,9 +22,9 @@ package openfl.display;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case StageQuality.BEST: "best";
 			case StageQuality.HIGH: "high";

--- a/src/openfl/display/StageScaleMode.hx
+++ b/src/openfl/display/StageScaleMode.hx
@@ -22,9 +22,9 @@ package openfl.display;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case StageScaleMode.EXACT_FIT: "exactFit";
 			case StageScaleMode.NO_BORDER: "noBorder";

--- a/src/openfl/display/TriangleCulling.hx
+++ b/src/openfl/display/TriangleCulling.hx
@@ -20,9 +20,9 @@ package openfl.display;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case TriangleCulling.NEGATIVE: "negative";
 			case TriangleCulling.NONE: "none";

--- a/src/openfl/display3D/Context3DBlendFactor.hx
+++ b/src/openfl/display3D/Context3DBlendFactor.hx
@@ -35,9 +35,9 @@ import openfl._internal.utils.NullUtils;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DBlendFactor.DESTINATION_ALPHA: "destinationAlpha";
 			case Context3DBlendFactor.DESTINATION_COLOR: "destinationColor";

--- a/src/openfl/display3D/Context3DBufferUsage.hx
+++ b/src/openfl/display3D/Context3DBufferUsage.hx
@@ -19,9 +19,9 @@ import openfl._internal.utils.NullUtils;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DBufferUsage.DYNAMIC_DRAW: "dynamicDraw";
 			case Context3DBufferUsage.STATIC_DRAW: "staticDraw";

--- a/src/openfl/display3D/Context3DCompareMode.hx
+++ b/src/openfl/display3D/Context3DCompareMode.hx
@@ -31,9 +31,9 @@ import openfl._internal.utils.NullUtils;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DCompareMode.ALWAYS: "always";
 			case Context3DCompareMode.EQUAL: "equal";

--- a/src/openfl/display3D/Context3DMipFilter.hx
+++ b/src/openfl/display3D/Context3DMipFilter.hx
@@ -21,9 +21,9 @@ import openfl._internal.utils.NullUtils;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DMipFilter.MIPLINEAR: "miplinear";
 			case Context3DMipFilter.MIPNEAREST: "mipnearest";

--- a/src/openfl/display3D/Context3DProfile.hx
+++ b/src/openfl/display3D/Context3DProfile.hx
@@ -29,9 +29,9 @@ import openfl._internal.utils.NullUtils;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DProfile.BASELINE: "baseline";
 			case Context3DProfile.BASELINE_CONSTRAINED: "baselineConstrained";

--- a/src/openfl/display3D/Context3DProgramType.hx
+++ b/src/openfl/display3D/Context3DProgramType.hx
@@ -19,9 +19,9 @@ import openfl._internal.utils.NullUtils;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DProgramType.FRAGMENT: "fragment";
 			case Context3DProgramType.VERTEX: "vertex";

--- a/src/openfl/display3D/Context3DRenderMode.hx
+++ b/src/openfl/display3D/Context3DRenderMode.hx
@@ -19,9 +19,9 @@ import openfl._internal.utils.NullUtils;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DRenderMode.AUTO: "auto";
 			case Context3DRenderMode.SOFTWARE: "software";

--- a/src/openfl/display3D/Context3DStencilAction.hx
+++ b/src/openfl/display3D/Context3DStencilAction.hx
@@ -31,9 +31,9 @@ import openfl._internal.utils.NullUtils;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DStencilAction.DECREMENT_SATURATE: "decrementSaturate";
 			case Context3DStencilAction.DECREMENT_WRAP: "decrementWrap";

--- a/src/openfl/display3D/Context3DTextureFilter.hx
+++ b/src/openfl/display3D/Context3DTextureFilter.hx
@@ -27,9 +27,9 @@ import openfl._internal.utils.NullUtils;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DTextureFilter.ANISOTROPIC16X: "anisotropic16x";
 			case Context3DTextureFilter.ANISOTROPIC2X: "anisotropic2x";

--- a/src/openfl/display3D/Context3DTextureFormat.hx
+++ b/src/openfl/display3D/Context3DTextureFormat.hx
@@ -27,9 +27,9 @@ import openfl._internal.utils.NullUtils;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DTextureFormat.BGR_PACKED: "bgrPacked565";
 			case Context3DTextureFormat.BGRA: "bgra";

--- a/src/openfl/display3D/Context3DTriangleFace.hx
+++ b/src/openfl/display3D/Context3DTriangleFace.hx
@@ -23,9 +23,9 @@ import openfl._internal.utils.NullUtils;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DTriangleFace.BACK: "back";
 			case Context3DTriangleFace.FRONT: "front";

--- a/src/openfl/display3D/Context3DVertexBufferFormat.hx
+++ b/src/openfl/display3D/Context3DVertexBufferFormat.hx
@@ -25,9 +25,9 @@ import openfl._internal.utils.NullUtils;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DVertexBufferFormat.BYTES_4: "bytes4";
 			case Context3DVertexBufferFormat.FLOAT_1: "float1";

--- a/src/openfl/display3D/Context3DWrapMode.hx
+++ b/src/openfl/display3D/Context3DWrapMode.hx
@@ -23,9 +23,9 @@ import openfl._internal.utils.NullUtils;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Context3DWrapMode.CLAMP: "clamp";
 			case Context3DWrapMode.CLAMP_U_REPEAT_V: "clamp_u_repeat_y";

--- a/src/openfl/filters/BitmapFilterType.hx
+++ b/src/openfl/filters/BitmapFilterType.hx
@@ -20,9 +20,9 @@ package openfl.filters;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case BitmapFilterType.FULL: "full";
 			case BitmapFilterType.INNER: "inner";

--- a/src/openfl/geom/Orientation3D.hx
+++ b/src/openfl/geom/Orientation3D.hx
@@ -20,9 +20,9 @@ package openfl.geom;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Orientation3D.AXIS_ANGLE: "axisAngle";
 			case Orientation3D.EULER_ANGLES: "eulerAngles";

--- a/src/openfl/net/SharedObjectFlushStatus.hx
+++ b/src/openfl/net/SharedObjectFlushStatus.hx
@@ -18,9 +18,9 @@ package openfl.net;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case SharedObjectFlushStatus.FLUSHED: "flushed";
 			case SharedObjectFlushStatus.PENDING: "pending";

--- a/src/openfl/net/URLLoaderDataFormat.hx
+++ b/src/openfl/net/URLLoaderDataFormat.hx
@@ -20,9 +20,9 @@ package openfl.net;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case URLLoaderDataFormat.BINARY: "binary";
 			case URLLoaderDataFormat.TEXT: "text";

--- a/src/openfl/printing/PrintJobOrientation.hx
+++ b/src/openfl/printing/PrintJobOrientation.hx
@@ -18,9 +18,9 @@ package openfl.printing;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case PrintJobOrientation.LANDSCAPE: "landscape";
 			case PrintJobOrientation.PORTRAIT: "portrait";

--- a/src/openfl/system/TouchscreenType.hx
+++ b/src/openfl/system/TouchscreenType.hx
@@ -20,9 +20,9 @@ package openfl.system;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case TouchscreenType.FINGER: "finger";
 			case TouchscreenType.NONE: "none";

--- a/src/openfl/text/AntiAliasType.hx
+++ b/src/openfl/text/AntiAliasType.hx
@@ -18,9 +18,9 @@ package openfl.text;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case AntiAliasType.ADVANCED: "advanced";
 			case AntiAliasType.NORMAL: "normal";

--- a/src/openfl/text/FontStyle.hx
+++ b/src/openfl/text/FontStyle.hx
@@ -22,9 +22,9 @@ package openfl.text;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case FontStyle.BOLD: "bold";
 			case FontStyle.BOLD_ITALIC: "boldItalic";

--- a/src/openfl/text/FontType.hx
+++ b/src/openfl/text/FontType.hx
@@ -20,9 +20,9 @@ package openfl.text;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case FontType.DEVICE: "device";
 			case FontType.EMBEDDED: "embedded";

--- a/src/openfl/text/GridFitType.hx
+++ b/src/openfl/text/GridFitType.hx
@@ -20,9 +20,9 @@ package openfl.text;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case GridFitType.NONE: "none";
 			case GridFitType.PIXEL: "pixel";

--- a/src/openfl/text/TextFieldAutoSize.hx
+++ b/src/openfl/text/TextFieldAutoSize.hx
@@ -22,9 +22,9 @@ package openfl.text;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case TextFieldAutoSize.CENTER: "center";
 			case TextFieldAutoSize.LEFT: "left";

--- a/src/openfl/text/TextFieldType.hx
+++ b/src/openfl/text/TextFieldType.hx
@@ -18,9 +18,9 @@ package openfl.text;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case TextFieldType.DYNAMIC: "dynamic";
 			case TextFieldType.INPUT: "input";

--- a/src/openfl/text/TextFormatAlign.hx
+++ b/src/openfl/text/TextFormatAlign.hx
@@ -26,9 +26,9 @@ package openfl.text;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case TextFormatAlign.CENTER: "center";
 			case TextFormatAlign.END: "end";

--- a/src/openfl/ui/MultitouchInputMode.hx
+++ b/src/openfl/ui/MultitouchInputMode.hx
@@ -20,9 +20,9 @@ package openfl.ui;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case MultitouchInputMode.GESTURE: "gesture";
 			case MultitouchInputMode.NONE: "none";

--- a/src/openfl/utils/CompressionAlgorithm.hx
+++ b/src/openfl/utils/CompressionAlgorithm.hx
@@ -21,9 +21,9 @@ package openfl.utils;
 		
 	}
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case CompressionAlgorithm.DEFLATE: "deflate";
 			case CompressionAlgorithm.LZMA: "lzma";

--- a/src/openfl/utils/Endian.hx
+++ b/src/openfl/utils/Endian.hx
@@ -37,9 +37,9 @@ import lime.system.Endian in LimeEndian;
 	}
 	
 	
-	@:to private static function toLimeEndian (value:Int):LimeEndian {
+	@:to private function toLimeEndian ():LimeEndian {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Endian.BIG_ENDIAN: LimeEndian.BIG_ENDIAN;
 			case Endian.LITTLE_ENDIAN: LimeEndian.LITTLE_ENDIAN;
@@ -50,9 +50,9 @@ import lime.system.Endian in LimeEndian;
 	}
 	
 	
-	@:to private static function toString (value:Int):String {
+	@:to private function toString ():String {
 		
-		return switch (value) {
+		return switch (cast this) {
 			
 			case Endian.BIG_ENDIAN: "bigEndian";
 			case Endian.LITTLE_ENDIAN: "littleEndian";


### PR DESCRIPTION
The definitions were invalid, although Haxe still alowed this and it somehow worked. Now the check is fixed Haxe will emit proper type errors.
See https://github.com/HaxeFoundation/haxe/issues/8579, https://github.com/HaxeFoundation/haxe/issues/8580 and https://github.com/openfl/openfl/commit/b4ae96d786b29e01991ea3706d53c6e34e6f1832