### PR TITLE
Always add 1px to the Graphics canvas even if it's not needed for half-pixel rendering.

### DIFF
--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -1062,9 +1062,12 @@ import js.html.CanvasRenderingContext2D;
 		__renderTransform.tx = __worldTransform.__transformInverseX (tx, ty);
 		__renderTransform.ty = __worldTransform.__transformInverseY (tx, ty);
 		
-		// Calculate the size to contain the graphics and the extra subpixel
-		var newWidth  = Math.ceil(width  + __renderTransform.tx);
-		var newHeight = Math.ceil(height + __renderTransform.ty);
+		// Calculate the size to contain the graphics and an extra subpixel
+		// We used to add tx and ty from __renderTransform instead of 1.0
+		// but it improves performance if we keep the size consistent when the
+		// extra pixel isn't needed
+		var newWidth = Math.ceil(width + 1.0);
+		var newHeight = Math.ceil(height + 1.0);
 		
 		// Mark dirty if render size changed
 		if (newWidth != __width || newHeight != __height) {


### PR DESCRIPTION
This will allow us to disable the `openfl_disable_graphics_upscaling` define which breaks Graphics/TextField scaling animation while still avoiding re-rendering when animating Graphics/TextField position (e.g. when scrolling FoE chat/market/messages).

This is also how the upstream OpenFL does it now, see https://github.com/openfl/openfl/commit/676ff119fae3d80e98b6c4890ca62d141da1965b