### PR TITLE
Strip input newline characters for non-multiline TextFields

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -3055,6 +3055,14 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 	
 	private function window_onTextInput (value:String):Void {
 		
+		if (!multiline) {
+			
+			// strip newlines when pasting the multi-line text,
+			// this is consistent with the Flash API
+			value = StringTools.replace (value, "\n", "");
+			
+		}
+		
 		replaceSelectedText (value);
 		
 		dispatchEvent (new Event (Event.CHANGE, true));


### PR DESCRIPTION
We only handle \n here because \r is supposed to be handled on the Lime level, see https://github.com/innogames/lime/pull/18