### PR TITLE
Rework/improve TextField copy-paste

### DIFF
--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -373,7 +373,6 @@ class Stage extends DisplayObjectContainer implements IModule {
 		window.onResize.add (onWindowResize.bind (window));
 		window.onRestore.add (onWindowRestore.bind (window));
 		window.onTextEdit.add (onTextEdit.bind (window));
-		window.onTextInput.add (onTextInput.bind (window));
 		
 	}
 	
@@ -699,37 +698,6 @@ class Stage extends DisplayObjectContainer implements IModule {
 	public function onTextEdit (window:Window, text:String, start:Int, length:Int):Void {
 		
 		//if (this.window == null || this.window != window) return;
-		
-	}
-	
-	
-	public function onTextInput (window:Window, text:String):Void {
-		
-		if (this.window == null || this.window != window) return;
-		
-		var stack = new Array <DisplayObject> ();
-		
-		if (__focus == null) {
-			
-			__getInteractive (stack);
-			
-		} else {
-			
-			__focus.__getInteractive (stack);
-			
-		}
-		
-		var event = new TextEvent (TextEvent.TEXT_INPUT, true, false, text);
-		if (stack.length > 0) {
-			
-			stack.reverse ();
-			__dispatchStack (event, stack);
-			
-		} else {
-			
-			__dispatchEvent (event);
-			
-		}
 		
 	}
 	


### PR DESCRIPTION
(depends on https://github.com/innogames/lime/pull/20)
- handle cut/copy/paste events from Lime instead of custom keyDown hackery
- treat input and paste separately and only handle non-multiline check for pasting
- dispatch TEXT_INPUT event from TextField directly, make it cancellable and support cancellation