### PR TITLE
Reset "visible" to true when drawing to BitmapData.

### DIFF
--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -109,6 +109,7 @@ class BitmapData implements IBitmapDrawable {
 	public var width (default, null):Int;
 	
 	private var __alpha:Float;
+	private var __visible:Bool;
 	private var __blendMode:BlendMode;
 	private var __buffer:GLBuffer;
 	private var __bufferColorTransform:ColorTransform;
@@ -579,11 +580,14 @@ class BitmapData implements IBitmapDrawable {
 			matrixCache.copyFrom (source.__worldTransform);
 			var cacheWorldAlpha = source.__worldAlpha;
 			var cacheAlpha = source.__alpha;
+			var cacheVisible = source.__visible;
 			source.__alpha = 1;
+			source.__visible = true;
 			source.__updateTransforms (matrix);
 			source.__updateChildren (false);
 			source.__renderCanvas (renderSession);
 			source.__alpha = cacheAlpha;
+			source.__visible = cacheVisible;
 			source.__updateTransforms (matrixCache);
 			Matrix.__pool.release (matrixCache);
 			source.__updateChildren (true);
@@ -662,11 +666,14 @@ class BitmapData implements IBitmapDrawable {
 			matrixCache.copyFrom (source.__worldTransform);
 			var cacheWorldAlpha = source.__worldAlpha;
 			var cacheAlpha = source.__alpha;
+			var cacheVisible = source.__visible;
 			source.__alpha = 1;
+			source.__visible = true;
 			source.__updateTransforms (matrix);
 			source.__updateChildren (false);
 			source.__renderCairo (renderSession);
 			source.__alpha = cacheAlpha;
+			source.__visible = cacheVisible;
 			source.__updateTransforms (matrixCache);
 			Matrix.__pool.release (matrixCache);
 			source.__updateChildren (true);
@@ -1831,7 +1838,9 @@ class BitmapData implements IBitmapDrawable {
 			matrixCache.copyFrom (source.__worldTransform);
 			var cacheWorldAlpha = source.__worldAlpha;
 			var cacheAlpha = source.__alpha;
+			var cacheVisible = source.__visible;
  			source.__alpha = 1;
+			source.__visible = true;
  			source.__updateTransforms (matrix);
 			source.__updateChildren (false);
 			
@@ -1845,6 +1854,7 @@ class BitmapData implements IBitmapDrawable {
 			source.__renderCanvas (renderSession);
 			source.__renderable = cacheRenderable;
 			source.__alpha = cacheAlpha;
+			source.__visible = cacheVisible;
 			
 			source.__updateTransforms (matrixCache);
 			Matrix.__pool.release (matrixCache);
@@ -1923,7 +1933,9 @@ class BitmapData implements IBitmapDrawable {
 			matrixCache.copyFrom (source.__worldTransform);
 			var cacheWorldAlpha = source.__worldAlpha;
 			var cacheAlpha = source.__alpha;
+			var cacheVisible = source.__visible;
  			source.__alpha = 1;
+			source.__visible = true;
 			source.__updateTransforms (matrix);
 			source.__updateChildren (false);
 			
@@ -1939,6 +1951,7 @@ class BitmapData implements IBitmapDrawable {
 			source.__renderCairo (renderSession);
 			source.__renderable = cacheRenderable;
 			source.__alpha = cacheAlpha;
+			source.__visible = cacheVisible;
 			
 			source.__updateTransforms (matrixCache);
 			Matrix.__pool.release (matrixCache);

--- a/src/openfl/display/IBitmapDrawable.hx
+++ b/src/openfl/display/IBitmapDrawable.hx
@@ -10,6 +10,7 @@ import openfl.geom.Rectangle;
 interface IBitmapDrawable {
 	
 	private var __alpha:Float;
+	private var __visible:Bool;
 	private var __blendMode:BlendMode;
 	private var __isMask:Bool;
 	private var __renderable:Bool;


### PR DESCRIPTION
I'm not a fan of this change as it makes BitmapData drawing methods even more complicated, but it's the least intrusive fix for the `BitmapData.draw` as well as `cacheAsBitmap`/`filters` when `visible` is `false`.

Some thoughts:
 - cache bitmap drawing currently occurs even when `visible = false` which caused FOE-55509. this fix ignores the `visible` setting and always draws, which fixes the issue, but arguably it would be better to only draw to the cache bitmap when the object becomes visible
 - when we're done with this "try not to change too much" BS, I think we should invert the bitmap drawing and have a `IBitmapDrawable.__draw` method instead of the current myriad of DO fields that we expose just for drawing.