### PR TITLE
Mark TextField as dirty when selecting all with Ctrl+A.

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -2950,8 +2950,7 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 				
 				if (#if mac modifier.metaKey #elseif js modifier.metaKey || modifier.ctrlKey #else modifier.ctrlKey #end) {
 					
-					__caretIndex = __text.length;
-					__selectionIndex = 0;
+					setSelection (0, __text.length);
 					
 				}
 			


### PR DESCRIPTION
Otherwise the selection will only be re-rendered on the next cursor blink which feels laggy.