### PR TITLE
cacheAsBitmap'd canvas alpha masking

### DIFF
--- a/src/openfl/_internal/renderer/AbstractMaskManager.hx
+++ b/src/openfl/_internal/renderer/AbstractMaskManager.hx
@@ -26,13 +26,6 @@ class AbstractMaskManager {
 	}
 	
 	
-	public function pushMask (mask:DisplayObject):Void {
-		
-		
-		
-	}
-	
-	
 	public function pushObject (object:DisplayObject, handleScrollRect:Bool = true):Void {
 		
 		
@@ -41,13 +34,6 @@ class AbstractMaskManager {
 	
 	
 	public function pushRect (rect:Rectangle, transform:Matrix):Void {
-		
-		
-		
-	}
-	
-	
-	public function popMask ():Void {
 		
 		
 		

--- a/src/openfl/_internal/renderer/cairo/CairoMaskManager.hx
+++ b/src/openfl/_internal/renderer/cairo/CairoMaskManager.hx
@@ -26,7 +26,7 @@ class CairoMaskManager extends AbstractMaskManager {
 	}
 	
 	
-	public override function pushMask (mask:DisplayObject):Void {
+	public function pushMask (mask:DisplayObject):Void {
 		
 		var cairo = renderSession.cairo;
 		
@@ -77,7 +77,7 @@ class CairoMaskManager extends AbstractMaskManager {
 	}
 	
 	
-	public override function popMask ():Void {
+	public function popMask ():Void {
 		
 		renderSession.cairo.restore ();
 		

--- a/src/openfl/_internal/renderer/canvas/CanvasBitmap.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasBitmap.hx
@@ -47,4 +47,20 @@ class CanvasBitmap {
 	}
 	
 	
+	public static inline function renderMaskPop (bitmap:Bitmap, renderSession:RenderSession):Void {
+		
+		#if (js && html5)
+		if (bitmap.__worldAlpha > 0 && bitmap.__bitmapData != null && bitmap.__bitmapData.__isValid && bitmap.__bitmapData.__canBeDrawnToCanvas ()) {
+			
+			var context = renderSession.context;
+			
+			CanvasSmoothing.setEnabled(context, renderSession.allowSmoothing && bitmap.smoothing);
+			context.globalAlpha = bitmap.__worldAlpha;
+			bitmap.__bitmapData.__drawToCanvas (context, bitmap.__renderTransform, renderSession.roundPixels || bitmap.__snapToPixel (), renderSession.pixelRatio, bitmap.__scrollRect, true);
+			
+		}
+		#end
+		
+	}
+	
 }

--- a/src/openfl/_internal/renderer/canvas/CanvasGraphics.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasGraphics.hx
@@ -1106,7 +1106,7 @@ class CanvasGraphics {
 	}
 	
 	
-	public static function render (graphics:Graphics, renderSession:RenderSession, parentTransform:Matrix):Void {
+	public static function render (graphics:Graphics, renderSession:RenderSession):Void {
 		
 		#if (js && html5)
 		

--- a/src/openfl/_internal/renderer/canvas/CanvasMaskManager.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasMaskManager.hx
@@ -19,23 +19,10 @@ class CanvasMaskManager extends AbstractMaskManager {
 	}
 	
 	
-	public override function pushMask (mask:DisplayObject):Void {
+	public function pushMask (mask:DisplayObject):Void {
 		
-		var context = renderSession.context;
-		
-		context.save ();
-		
-		//var cacheAlpha = mask.__worldAlpha;
-		var transform = mask.__renderTransform;
-		var pixelRatio = renderSession.pixelRatio;
-		context.setTransform (transform.a * pixelRatio, transform.b, transform.c, transform.d * pixelRatio, transform.tx * pixelRatio, transform.ty * pixelRatio);
-		
-		context.beginPath ();
-		mask.__renderCanvasMask (renderSession);
-		
-		context.clip ();
-		
-		//mask.worldAlpha = cacheAlpha;
+		renderSession.context.save ();
+		mask.__canvasPushMask (renderSession);
 		
 	}
 	
@@ -72,8 +59,9 @@ class CanvasMaskManager extends AbstractMaskManager {
 	}
 	
 	
-	public override function popMask ():Void {
+	public function popMask (mask:DisplayObject):Void {
 		
+		mask.__canvasPopMask(renderSession);
 		renderSession.context.restore ();
 		
 	}
@@ -83,7 +71,7 @@ class CanvasMaskManager extends AbstractMaskManager {
 		
 		if (!object.__cacheBitmapRender && object.__mask != null) {
 			
-			popMask ();
+			popMask (object.__mask);
 			
 		}
 		

--- a/src/openfl/_internal/renderer/canvas/CanvasShape.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasShape.hx
@@ -25,7 +25,7 @@ class CanvasShape {
 		
 		if (graphics != null) {
 			
-			CanvasGraphics.render (graphics, renderSession, shape.__renderTransform);
+			CanvasGraphics.render (graphics, renderSession);
 			
 			var bounds = graphics.__bounds;
 			var width = graphics.__width;

--- a/src/openfl/_internal/renderer/dom/DOMMaskManager.hx
+++ b/src/openfl/_internal/renderer/dom/DOMMaskManager.hx
@@ -31,7 +31,7 @@ class DOMMaskManager extends AbstractMaskManager {
 	}
 	
 	
-	public override function pushMask (mask:DisplayObject):Void {
+	public function pushMask (mask:DisplayObject):Void {
 		
 		// TODO: Handle true mask shape, as well as alpha test
 		
@@ -95,7 +95,7 @@ class DOMMaskManager extends AbstractMaskManager {
 	}
 	
 	
-	public override function popMask ():Void {
+	public function popMask ():Void {
 		
 		popRect ();
 		

--- a/src/openfl/_internal/renderer/dom/DOMShape.hx
+++ b/src/openfl/_internal/renderer/dom/DOMShape.hx
@@ -41,7 +41,7 @@ class DOMShape {
 		
 		if (shape.stage != null && shape.__worldVisible && shape.__renderable && graphics != null) {
 			
-			CanvasGraphics.render (graphics, renderSession, shape.__renderTransform);
+			CanvasGraphics.render (graphics, renderSession);
 			
 			if (graphics.__dirty || shape.__worldAlphaChanged || (shape.__canvas != graphics.__canvas)) {
 				

--- a/src/openfl/_internal/renderer/opengl/GLGraphics.hx
+++ b/src/openfl/_internal/renderer/opengl/GLGraphics.hx
@@ -96,7 +96,7 @@ class GLGraphics {
 		if (!isCompatible (graphics, parentTransform)) {
 			
 			#if (js && html5)
-			CanvasGraphics.render (graphics, renderSession, parentTransform);
+			CanvasGraphics.render (graphics, renderSession);
 			#elseif lime_cairo
 			CairoGraphics.render (graphics, renderSession, parentTransform);
 			#end
@@ -207,7 +207,7 @@ class GLGraphics {
 		// TODO: Support invisible shapes
 		
 		#if (js && html5)
-		CanvasGraphics.render (graphics, renderSession, parentTransform);
+		CanvasGraphics.render (graphics, renderSession);
 		#elseif lime_cairo
 		CairoGraphics.render (graphics, renderSession, parentTransform);
 		#end

--- a/src/openfl/_internal/renderer/opengl/GLMaskManager.hx
+++ b/src/openfl/_internal/renderer/opengl/GLMaskManager.hx
@@ -49,7 +49,7 @@ class GLMaskManager extends AbstractMaskManager {
 	}
 	
 	
-	public override function pushMask (mask:DisplayObject):Void {
+	public function pushMask (mask:DisplayObject):Void {
 		
 		// flush everything in the current batch, since we're rendering stuff differently now
 		renderSession.batcher.flush ();
@@ -136,7 +136,7 @@ class GLMaskManager extends AbstractMaskManager {
 	}
 	
 	
-	public override function popMask ():Void {
+	public function popMask ():Void {
 		
 		if (stencilReference == 0) return;
 		

--- a/src/openfl/_internal/renderer/opengl/GLShape.hx
+++ b/src/openfl/_internal/renderer/opengl/GLShape.hx
@@ -38,7 +38,7 @@ class GLShape {
 		if (graphics != null) {
 			
 			#if (js && html5)
-			CanvasGraphics.render (graphics, renderSession, shape.__renderTransform);
+			CanvasGraphics.render (graphics, renderSession);
 			#elseif lime_cairo
 			CairoGraphics.render (graphics, renderSession, shape.__renderTransform);
 			#end
@@ -117,7 +117,7 @@ class GLShape {
 			// TODO: Support invisible shapes
 			
 			#if (js && html5)
-			CanvasGraphics.render (graphics, renderSession, shape.__renderTransform);
+			CanvasGraphics.render (graphics, renderSession);
 			#elseif lime_cairo
 			CairoGraphics.render (graphics, renderSession, shape.__renderTransform);
 			#end

--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -226,6 +226,21 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 	}
 	
 	
+	override function __canvasPopMask(renderSession:RenderSession) {
+		
+		if (cacheAsBitmap) {
+			
+			__updateCacheBitmap (renderSession, !__worldColorTransform.__isDefault ());
+			
+			var bitmap = if (__cacheBitmap != null) __cacheBitmap else this;
+			renderSession.context.globalCompositeOperation = "destination-in";
+			CanvasBitmap.renderMaskPop(bitmap, renderSession);
+			
+		}
+		
+	}
+	
+	
 	private override function __renderDOM (renderSession:RenderSession):Void {
 		
 		__updateCacheBitmap (renderSession, !__worldColorTransform.__isDefault ());

--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -221,6 +221,9 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 	
 	private override function __renderCanvasMask (renderSession:RenderSession):Void {
 		
+		var transform = __renderTransform;
+		var pixelRatio = renderSession.pixelRatio;
+		renderSession.context.setTransform (transform.a * pixelRatio, transform.b, transform.c, transform.d * pixelRatio, transform.tx * pixelRatio, transform.ty * pixelRatio);
 		renderSession.context.rect (0, 0, __bitmapData.width, __bitmapData.height);
 		
 	}

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -2145,12 +2145,6 @@ class BitmapData implements IBitmapDrawable {
 	}
 	
 	
-	private function __renderCairoMask (renderSession:RenderSession):Void {
-		
-		
-		
-	}
-	
 	#if (js && html5)
 	function __canBeDrawnToCanvas ():Bool {
 		
@@ -2213,13 +2207,6 @@ class BitmapData implements IBitmapDrawable {
 	}
 	
 	
-	private function __renderCanvasMask (renderSession:RenderSession):Void {
-		
-		
-		
-	}
-	
-	
 	private function __renderGL (renderSession:RenderSession):Void {
 		
 		var renderer:GLRenderer = cast renderSession.renderer;
@@ -2239,32 +2226,6 @@ class BitmapData implements IBitmapDrawable {
 		gl.vertexAttribPointer (shader.data.aPosition.index, 3, gl.FLOAT, false, 6 * Float32Array.BYTES_PER_ELEMENT, 0);
 		gl.vertexAttribPointer (shader.data.aTexCoord.index, 2, gl.FLOAT, false, 6 * Float32Array.BYTES_PER_ELEMENT, 3 * Float32Array.BYTES_PER_ELEMENT);
 		gl.vertexAttribPointer (shader.data.aAlpha.index, 1, gl.FLOAT, false, 6 * Float32Array.BYTES_PER_ELEMENT, 5 * Float32Array.BYTES_PER_ELEMENT);
-		
-		gl.drawArrays (gl.TRIANGLE_STRIP, 0, 4);
-		
-		#if gl_stats
-			GLStats.incrementDrawCall (DrawCallContext.STAGE);
-		#end
-		
-	}
-	
-	
-	private function __renderGLMask (renderSession:RenderSession):Void {
-		
-		var renderer:GLRenderer = cast renderSession.renderer;
-		var gl = renderSession.gl;
-		
-		var shader = (cast renderSession.maskManager:GLMaskManager).maskShader;
-		
-		shader.data.uImage0.input = this;
-		shader.data.uImage0.smoothing = renderSession.allowSmoothing && renderSession.forceSmoothing;
-		shader.data.uMatrix.value = renderer.getMatrix (__worldTransform);
-		
-		renderSession.shaderManager.setShader (shader);
-		
-		gl.bindBuffer (gl.ARRAY_BUFFER, getBuffer (gl, 1, __worldColorTransform));
-		gl.vertexAttribPointer (shader.data.aPosition.index, 3, gl.FLOAT, false, 6 * Float32Array.BYTES_PER_ELEMENT, 0);
-		gl.vertexAttribPointer (shader.data.aTexCoord.index, 2, gl.FLOAT, false, 6 * Float32Array.BYTES_PER_ELEMENT, 3 * Float32Array.BYTES_PER_ELEMENT);
 		
 		gl.drawArrays (gl.TRIANGLE_STRIP, 0, 4);
 		

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -581,13 +581,16 @@ class BitmapData implements IBitmapDrawable {
 			var cacheWorldAlpha = source.__worldAlpha;
 			var cacheAlpha = source.__alpha;
 			var cacheVisible = source.__visible;
+			var cacheIsMask = source.__isMask;
 			source.__alpha = 1;
 			source.__visible = true;
+			source.__isMask = false;
 			source.__updateTransforms (matrix);
 			source.__updateChildren (false);
 			source.__renderCanvas (renderSession);
 			source.__alpha = cacheAlpha;
 			source.__visible = cacheVisible;
+			source.__isMask = cacheIsMask;
 			source.__updateTransforms (matrixCache);
 			Matrix.__pool.release (matrixCache);
 			source.__updateChildren (true);
@@ -667,13 +670,16 @@ class BitmapData implements IBitmapDrawable {
 			var cacheWorldAlpha = source.__worldAlpha;
 			var cacheAlpha = source.__alpha;
 			var cacheVisible = source.__visible;
+			var cacheIsMask = source.__isMask;
 			source.__alpha = 1;
 			source.__visible = true;
+			source.__isMask = false;
 			source.__updateTransforms (matrix);
 			source.__updateChildren (false);
 			source.__renderCairo (renderSession);
 			source.__alpha = cacheAlpha;
 			source.__visible = cacheVisible;
+			source.__isMask = cacheIsMask;
 			source.__updateTransforms (matrixCache);
 			Matrix.__pool.release (matrixCache);
 			source.__updateChildren (true);
@@ -1839,22 +1845,17 @@ class BitmapData implements IBitmapDrawable {
 			var cacheWorldAlpha = source.__worldAlpha;
 			var cacheAlpha = source.__alpha;
 			var cacheVisible = source.__visible;
+			var cacheIsMask = source.__isMask;
  			source.__alpha = 1;
 			source.__visible = true;
+			source.__isMask = false;
  			source.__updateTransforms (matrix);
 			source.__updateChildren (false);
 			
-			var cacheRenderable = source.__renderable;
-			if (source.__isMask) {
-				
-				source.__renderable = true;
-				
-			}
-			
 			source.__renderCanvas (renderSession);
-			source.__renderable = cacheRenderable;
 			source.__alpha = cacheAlpha;
 			source.__visible = cacheVisible;
+			source.__isMask = cacheIsMask;
 			
 			source.__updateTransforms (matrixCache);
 			Matrix.__pool.release (matrixCache);
@@ -1934,24 +1935,17 @@ class BitmapData implements IBitmapDrawable {
 			var cacheWorldAlpha = source.__worldAlpha;
 			var cacheAlpha = source.__alpha;
 			var cacheVisible = source.__visible;
+			var cacheIsMask = source.__isMask;
  			source.__alpha = 1;
 			source.__visible = true;
+			source.__isMask = false;
 			source.__updateTransforms (matrix);
 			source.__updateChildren (false);
 			
-			// TODO: Force renderable using render session?
-			
-			var cacheRenderable = source.__renderable;
-			if (source.__isMask) {
-				
-				source.__renderable = true;
-				
-			}
- 			
 			source.__renderCairo (renderSession);
-			source.__renderable = cacheRenderable;
 			source.__alpha = cacheAlpha;
 			source.__visible = cacheVisible;
+			source.__isMask = cacheIsMask;
 			
 			source.__updateTransforms (matrixCache);
 			Matrix.__pool.release (matrixCache);

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -847,6 +847,10 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		
 		if (__graphics != null) {
 			
+			var transform = __renderTransform;
+			var pixelRatio = renderSession.pixelRatio;
+			renderSession.context.setTransform (transform.a * pixelRatio, transform.b, transform.c, transform.d * pixelRatio, transform.tx * pixelRatio, transform.ty * pixelRatio);
+			
 			CanvasGraphics.renderMask (__graphics, renderSession);
 			
 		}
@@ -859,9 +863,6 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		if (!cacheAsBitmap) {
 			
 			var context = renderSession.context;
-			var transform = __renderTransform;
-			var pixelRatio = renderSession.pixelRatio;
-			context.setTransform (transform.a * pixelRatio, transform.b, transform.c, transform.d * pixelRatio, transform.tx * pixelRatio, transform.ty * pixelRatio);
 			
 			context.beginPath ();
 			__renderCanvasMask (renderSession);

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -854,6 +854,45 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 	}
 	
 	
+	private function __canvasPushMask (renderSession:RenderSession):Void {
+		
+		if (!cacheAsBitmap) {
+			
+			var context = renderSession.context;
+			var transform = __renderTransform;
+			var pixelRatio = renderSession.pixelRatio;
+			context.setTransform (transform.a * pixelRatio, transform.b, transform.c, transform.d * pixelRatio, transform.tx * pixelRatio, transform.ty * pixelRatio);
+			
+			context.beginPath ();
+			__renderCanvasMask (renderSession);
+			context.clip ();
+			
+		}
+		
+	}
+	
+	
+	private function __canvasPopMask (renderSession:RenderSession):Void {
+		
+		if (cacheAsBitmap) {
+			
+			__isMask = false;
+			__updateCacheBitmap (renderSession, !__worldColorTransform.__isDefault ());
+			__isMask = true;
+			__updateChildren(true);
+			
+			if (__cacheBitmap != null) {
+				
+				renderSession.context.globalCompositeOperation = "destination-in";
+				CanvasBitmap.renderMaskPop(__cacheBitmap, renderSession);
+				
+			}
+			
+		}
+		
+	}
+	
+	
 	private function __renderDOM (renderSession:RenderSession):Void {
 		
 		__updateCacheBitmap (renderSession, !__worldColorTransform.__isDefault ());

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -876,10 +876,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 		
 		if (cacheAsBitmap) {
 			
-			__isMask = false;
 			__updateCacheBitmap (renderSession, !__worldColorTransform.__isDefault ());
-			__isMask = true;
-			__updateChildren(true);
 			
 			if (__cacheBitmap != null) {
 				

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -771,23 +771,13 @@ class DisplayObjectContainer extends InteractiveObject {
 	
 	private override function __renderCanvasMask (renderSession:RenderSession):Void {
 		
-		if (__graphics != null) {
+		super.__renderCanvasMask (renderSession);
+		
+		for (child in __children) {
 			
-			CanvasGraphics.renderMask (__graphics, renderSession);
+			child.__renderCanvasMask (renderSession);
 			
 		}
-		
-		var bounds = Rectangle.__pool.get ();
-		__getLocalBounds (bounds);
-		
-		renderSession.context.rect (0, 0, bounds.width, bounds.height);
-		
-		Rectangle.__pool.release (bounds);
-		/*for (child in __children) {
-			
-			child.__renderMask (renderSession);
-			
-		}*/
 		
 	}
 	

--- a/src/openfl/display/IBitmapDrawable.hx
+++ b/src/openfl/display/IBitmapDrawable.hx
@@ -21,11 +21,8 @@ interface IBitmapDrawable {
 	
 	private function __getBounds (rect:Rectangle, matrix:Matrix):Void;
 	private function __renderCairo (renderSession:RenderSession):Void;
-	private function __renderCairoMask (renderSession:RenderSession):Void;
 	private function __renderCanvas (renderSession:RenderSession):Void;
-	private function __renderCanvasMask (renderSession:RenderSession):Void;
 	private function __renderGL (renderSession:RenderSession):Void;
-	private function __renderGLMask (renderSession:RenderSession):Void;
 	private function __updateChildren (transformOnly:Bool):Void;
 	private function __updateTransforms (?overrideTransform:Matrix = null):Void;
 	

--- a/src/openfl/display/SimpleButton.hx
+++ b/src/openfl/display/SimpleButton.hx
@@ -298,13 +298,13 @@ class SimpleButton extends InteractiveObject {
 	
 	private override function __renderCanvasMask (renderSession:RenderSession):Void {
 		
-		var bounds = Rectangle.__pool.get ();
-		__getLocalBounds (bounds);
+		super.__renderCanvasMask (renderSession);
 		
-		renderSession.context.rect (0, 0, bounds.width, bounds.height);
-		
-		Rectangle.__pool.release (bounds);
-		__currentState.__renderCanvasMask (renderSession);
+		if (__currentState != null) {
+			
+			__currentState.__renderCanvasMask (renderSession);
+			
+		}
 		
 	}
 	


### PR DESCRIPTION
In Flash, when using a `Bitmap` as a mask, normally it doesn't care whether pixel in the mask is transparent or not, so the mask is always rectangular. However, it also [supports proper alpha masking](https://help.adobe.com/en_US/as3/dev/WS5b3ccc516d4fbf351e63e3d118a9b90204-7e0b.html#WS2d8d13466044a7332384449d1277856ffe8-8000), if both the mask and the masked object have `cacheAsBitmap = true`. 

In OpenFL, currently the situation is different:
 - When rendering through GL, alpha is always considered, as the mask shader always discard zero-alpha pixels.
 - When rendering through Canvas (`BitmapData.draw` or cache bitmap rendering), alpha is never considered, it simply uses the bounds rectangle as the ["clipping path"](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/clip).

This change will make alpha masking work when the mask object have `cacheAsBitmap = true`.

For this to work, we have to render the mask differently. Instead of setting the clipping path on the canvas _BEFORE_ rendering the masked object, we have to actually render the mask Bitmap with a special blend mode _AFTER_ rendering the masked object.

So we have now two possible behaviours completely depending on the kind of the display object and its `cacheAsBitmap` setting (thus the refactoring).

Also, because we need to update cache bitmap for masks, I also fixed `BitmapData.draw/__draw` to temporarily make the object not-mask so it and its children becomes actually renderable.

UPD: also fixed masking with the containers 