### PR TITLE
use unscaled width/height for BitmapData.__renderCanvasMask

### DIFF
--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -221,7 +221,7 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 	
 	private override function __renderCanvasMask (renderSession:RenderSession):Void {
 		
-		renderSession.context.rect (0, 0, width, height);
+		renderSession.context.rect (0, 0, __bitmapData.width, __bitmapData.height);
 		
 	}
 	


### PR DESCRIPTION
because the display object transform is already applied when __renderCanvasMask is called