### PR TITLE
fix cache bitmap transform invalidation checking

### DIFF
--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1135,7 +1135,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 			//if (!renderSession.lockTransform) __getWorldTransform ();
 			
 			var needRender = (__cacheBitmap == null || __cacheBitmapNeedsRender ());
-			var updateTransform = (needRender || !__cacheBitmap.__renderTransform.equals (__renderTransform));
+			var updateTransform = (needRender || !__cacheBitmap.__worldTransform.equals (__renderTransform));
 			var hasFilters = __hasFilters ();
 			var pixelRatio = renderSession.pixelRatio;
 			
@@ -1209,7 +1209,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable #if openf
 			
 			if (updateTransform || needRender) {
 			
-				__cacheBitmap.__worldTransform.copyFrom (__worldTransform);
+				__cacheBitmap.__worldTransform.copyFrom (__renderTransform);
 				
 				__cacheBitmap.__renderTransform.identity ();
 				__cacheBitmap.__renderTransform.tx = rect.x;


### PR DESCRIPTION
__renderTransform on __cacheBitmap is something different from the object's own __renderTransform, so we should store object's __renderTransform somewhere else to check it later. and we (ab)use __cacheBitmap.__worldTransform for this.

this fixes the performance regression introduced by #104