### PR TITLE
extract __isPointInScrollRect instead of copy-pasting the code

### DIFF
--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -527,20 +527,9 @@ class DisplayObjectContainer extends InteractiveObject {
 		if (!hitObject.visible || __isMask || (!hitTestWhenMouseDisabled && interactiveOnly && !mouseEnabled && !mouseChildren)) return false;
 		if (mask != null && !mask.__hitTestMask (x, y)) return false;
 		
-		if (__scrollRect != null) {
+		if (!__isPointInScrollRect (x, y)) {
 			
-			var point = Point.__pool.get ();
-			point.setTo (x, y);
-			__getRenderTransform ().__transformInversePoint (point);
-			
-			if (!__scrollRect.containsPoint (point)) {
-				
-				Point.__pool.release (point);
-				return false;
-				
-			}
-			
-			Point.__pool.release (point);
+			return false;
 			
 		}
 		
@@ -647,6 +636,36 @@ class DisplayObjectContainer extends InteractiveObject {
 	private override function __mouseThroughAllowed ():Bool {
 		
 		return mouseEnabled || mouseChildren;
+		
+	}
+	
+	
+	/**
+		Check whether given point (x, y) is within `this.scrollRect`.
+		
+		Returns `true` if the `scrollRect` contains given coordinates, `false` otherwise.
+		When `scrollRect` is `null`, also returns `true`.
+	**/
+	function __isPointInScrollRect (x:Float, y:Float):Bool {
+		
+		if (__scrollRect != null) {
+			
+			var point = Point.__pool.get ();
+			point.setTo (x, y);
+			__getRenderTransform ().__transformInversePoint (point);
+			
+			if (!__scrollRect.containsPoint (point)) {
+				
+				Point.__pool.release (point);
+				return false;
+				
+			}
+			
+			Point.__pool.release (point);
+			
+		}
+		
+		return true;
 		
 	}
 	

--- a/src/openfl/display/Sprite.hx
+++ b/src/openfl/display/Sprite.hx
@@ -98,20 +98,9 @@ class Sprite extends DisplayObjectContainer {
 		
 		if (mask != null && !mask.__hitTestMask (x, y)) return __hitTestHitArea (x, y, shapeFlag, stack, interactiveOnly, hitObject, hitTestWhenMouseDisabled);
 		
-		if (__scrollRect != null) {
+		if (!__isPointInScrollRect (x, y)) {
 			
-			var point = Point.__pool.get ();
-			point.setTo (x, y);
-			__getRenderTransform ().__transformInversePoint (point);
-			
-			if (!__scrollRect.containsPoint (point)) {
-				
-				Point.__pool.release (point);
-				return __hitTestHitArea (x, y, shapeFlag, stack, true, hitObject, hitTestWhenMouseDisabled);
-				
-			}
-			
-			Point.__pool.release (point);
+			return __hitTestHitArea (x, y, shapeFlag, stack, true, hitObject, hitTestWhenMouseDisabled);
 			
 		}
 		


### PR DESCRIPTION
I'm trying to read the `__hitTest` functions and it's very hard so I decided to do some small cleanups along the way...