### PR TITLE
Batcher viewport and contentsScaleFactor fix

### DIFF
--- a/src/openfl/_internal/renderer/opengl/GLRenderer.hx
+++ b/src/openfl/_internal/renderer/opengl/GLRenderer.hx
@@ -230,6 +230,8 @@ class GLRenderer extends AbstractRenderer {
 		
 		// setup projection matrix for the batcher as it's an uniform value for all the draw calls
 		renderSession.batcher.projectionMatrix = flipped ? projectionFlipped : projection;
+		// also pass the viewport to the batcher because it uses it for the out-of-screen quad culling
+		renderSession.batcher.setViewport(offsetX, offsetY, displayWidth, displayHeight);
 		
 		stage.__renderGL (renderSession);
 		
@@ -326,8 +328,6 @@ class GLRenderer extends AbstractRenderer {
 		offsetY = Math.round (displayMatrix.__transformY (0, 0));
 		displayWidth = Math.round (displayMatrix.__transformX (w, 0) - offsetX);
 		displayHeight = Math.round (displayMatrix.__transformY (0, h) - offsetY);
-		
-		renderSession.batcher.setViewport(offsetX, offsetY, displayWidth, displayHeight);
 		
 		projection = Matrix4.createOrtho (offsetX, displayWidth + offsetX, offsetY, displayHeight + offsetY, -1000, 1000);
 		projectionFlipped = Matrix4.createOrtho (offsetX, displayWidth + offsetX, displayHeight + offsetY, offsetY, -1000, 1000);

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -1900,6 +1900,18 @@ class Stage extends DisplayObjectContainer implements IModule {
 			
 		}
 		
+		if (__contentsScaleFactor != window.scale && __renderer != null) {
+			
+			__contentsScaleFactor = window.scale;
+			
+			#if (js && html5)
+				@:privateAccess (__renderer.renderSession).pixelRatio = window.scale;
+			#end
+			
+			__forceRenderDirty();
+			
+		}
+		
 		for (stage3D in stage3Ds) {
 			
 			stage3D.__resize (stageWidth, stageHeight);
@@ -1915,18 +1927,6 @@ class Stage extends DisplayObjectContainer implements IModule {
 		if (stageWidth != cacheWidth || stageHeight != cacheHeight) {
 			
 			__dispatchEvent (new Event (Event.RESIZE));
-			
-		}
-		
-		if (__contentsScaleFactor != window.scale && __renderer != null) {
-			
-			__contentsScaleFactor = window.scale;
-			
-			#if (js && html5)
-				@:privateAccess (__renderer.renderSession).pixelRatio = window.scale;
-			#end
-			
-			__forceRenderDirty();
 			
 		}
 		


### PR DESCRIPTION
- Set batcher viewport before rendering (because the batcher is re-used by Starling with a different viewport)
- Set `contentsScaleFactor` before dispatching `Event.RESIZE` (to be consistent with Flash)