### PR TITLE
Greatly simplify lime.app.Event

### DIFF
--- a/src/lime/_macros/EventMacro.hx
+++ b/src/lime/_macros/EventMacro.hx
@@ -1,167 +1,28 @@
-package lime._macros; #if macro
+package lime._macros;
 
-
+#if macro
 import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;
 
 using haxe.macro.Tools;
 
-
 class EventMacro {
-	
-	
-	public static function build () {
-		
-		var typeArgs;
-		var typeResult;
-		
-		switch (Context.follow (Context.getLocalType ())) {
-			
-			case TInst (_, [ Context.follow (_) => TFun (args, result) ]):
-				
-				typeArgs = args;
-				typeResult = result;
-			
-			case TInst (localType, _):
-				
-				Context.fatalError ("Invalid number of type parameters for " + localType.toString (), Context.currentPos ());
-				return null;
-			
-			default:
-				
-				throw false;
-			
+	public static function build() {
+		var typeArgs = switch (Context.getLocalType()) {
+			case TInst(_, [_.follow() => TFun(args, _)]): args;
+			case _: throw new Error("Invalid type parameter for Event", Context.currentPos());
 		}
-		
-		var typeParam = TFun (typeArgs, typeResult);
-		var typeString = "";
-		
-		if (typeArgs.length == 0) {
-			
-			typeString = "Void->";
-			
-		} else {
-			
-			for (arg in typeArgs) {
-				
-				typeString += arg.t.toString () + "->";
-				
-			}
-			
-		}
-		
-		typeString += typeResult.toString ();
-		typeString = StringTools.replace (typeString, "->", "_");
-		typeString = StringTools.replace (typeString, ".", "_");
-		typeString = StringTools.replace (typeString, "<", "_");
-		typeString = StringTools.replace (typeString, ">", "_");
-		
-		var name = "_Event_" + typeString;
-		
-		try {
-			
-			Context.getType ("lime.app." + name);
-			
-		} catch (e:Dynamic) {
-			
-			var pos = Context.currentPos ();
-			var fields = Context.getBuildFields ();
-			
-			var args:Array<FunctionArg> = [];
-			var argName, argNames = [];
-			
-			for (i in 0...typeArgs.length) {
-				
-				if (i == 0) {
-					
-					argName = "a";
-					
-				} else {
-					
-					argName = "a" + i;
-					
-				}
-				
-				argNames.push (Context.parse (argName, pos));
-				args.push ({ name: argName, type: typeArgs[i].t.toComplexType () });
-				
-			}
-			
-			var dispatch = macro {
-				
-				canceled = false;
-				
-				var listeners = __listeners;
-				var repeat = __repeat;
-				var i = 0;
-				
-				while (i < listeners.length) {
-					
-					listeners[i] ($a{argNames});
-					
-					if (!repeat[i]) {
-						
-						this.remove (cast listeners[i]);
-						
-					} else {
-						
-						i++;
-						
-					}
-					
-					if (canceled) {
-						
-						break;
-						
-					}
-					
-				}
-				
-			}
-			
-			var i = 0;
-			var field;
-			
-			while (i < fields.length) {
-				
-				field = fields[i];
-				
-				if (field.name == "__listeners" || field.name == "dispatch") {
-					
-					fields.remove (field);
-					
-				} else {
-					
-					i++;
-					
-				}
-				
-			}
-			
-			fields.push ( { name: "__listeners", access: [ APublic ], kind: FVar (TPath ({ pack: [], name: "Array", params: [ TPType (typeParam.toComplexType ()) ] })), pos: pos } );
-			fields.push ( { name: "dispatch", access: [ APublic ], kind: FFun ( { args: args, expr: dispatch, params: [], ret: macro :Void } ), pos: pos } );
-			
-			Context.defineType ({
-				
-				pos: pos,
-				pack: [ "lime", "app" ],
-				name: name,
-				kind: TDClass (),
-				fields: fields,
-				params: [ { name: "T" } ],
-				meta: [ { name: ":dox", params: [ macro hide ], pos: pos }, { name: ":noCompletion", pos: pos } ]
-				
-			});
-			
-		}
-		
-		return TPath ( { pack: [ "lime", "app" ], name: name, params: [ TPType (typeParam.toComplexType ()) ] } ).toType ();
-		
+
+		var eventClassName = "Event" + (typeArgs.length);
+		var typeParams = [for (arg in typeArgs) TPType(arg.t.toComplexType())];
+
+		return TPath({
+			pack: ["lime", "app"],
+			name: "Event",
+			sub: eventClassName,
+			params: typeParams
+		});
 	}
-	
-	
 }
-
-
 #end

--- a/src/lime/app/Event.hx
+++ b/src/lime/app/Event.hx
@@ -1,293 +1,97 @@
 package lime.app;
 
-
-#if macro
-import haxe.macro.Context;
-import haxe.macro.Expr;
-import haxe.macro.Type;
-using haxe.macro.Tools;
-#end
-
-#if (!macro && !display)
 @:genericBuild(lime._macros.EventMacro.build())
-#end
+class Event<T> {}
 
-#if !lime_debug
-@:fileXml('tags="haxe,release"')
-@:noDebug
-#end
-
-
-class Event<T> {
-	
-	
-	public var canceled (default, null):Bool;
-	
-	@:noCompletion @:dox(hide) public var __listeners:Array<T>;
-	@:noCompletion @:dox(hide) public var __repeat:Array<Bool>;
-	private var __priorities:Array<Int>;
-	
-	
-	public function new () {
-		
-		#if !macro
+class Event0 extends BaseEvent<Void->Void> {
+	public function dispatch() {
 		canceled = false;
-		__listeners = new Array ();
-		__priorities = new Array<Int> ();
-		__repeat = new Array<Bool> ();
-		#end
-		
+		for (listener in __listeners) {
+			listener();
+			if (canceled)
+				break;
+		}
 	}
-	
-	
-	public function add (listener:T, once:Bool = false, priority:Int = 0):Void {
-		
-		#if !macro
+}
+
+class Event1<T> extends BaseEvent<T->Void> {
+	public function dispatch(arg:T) {
+		canceled = false;
+		for (listener in __listeners) {
+			listener(arg);
+			if (canceled)
+				break;
+		}
+	}
+}
+
+class Event2<T1, T2> extends BaseEvent<T1->T2->Void> {
+	public function dispatch(arg1:T1, arg2:T2) {
+		canceled = false;
+		for (listener in __listeners) {
+			listener(arg1, arg2);
+			if (canceled)
+				break;
+		}
+	}
+}
+
+class Event3<T1, T2, T3> extends BaseEvent<T1->T2->T3->Void> {
+	public function dispatch(arg1:T1, arg2:T2, arg3:T3) {
+		canceled = false;
+		for (listener in __listeners) {
+			listener(arg1, arg2, arg3);
+			if (canceled)
+				break;
+		}
+	}
+}
+
+private class BaseEvent<T> {
+	public var canceled(default, null):Bool;
+
+	var __listeners:Array<T>;
+	var __priorities:Array<Int>;
+
+	public function new() {
+		canceled = false;
+		__listeners = new Array();
+		__priorities = new Array<Int>();
+	}
+
+	public function add(listener:T, priority:Int = 0):Void {
 		for (i in 0...__priorities.length) {
-			
 			if (priority > __priorities[i]) {
-				
-				__listeners.insert (i, cast listener);
-				__priorities.insert (i, priority);
-				__repeat.insert (i, !once);
+				__listeners.insert(i, listener);
+				__priorities.insert(i, priority);
 				return;
-				
 			}
-			
 		}
-		
-		__listeners.push (cast listener);
-		__priorities.push (priority);
-		__repeat.push (!once);
-		#end
-		
+
+		__listeners.push(listener);
+		__priorities.push(priority);
 	}
-	
-	
-	#if macro
-	private static function build () {
-		
-		var typeArgs;
-		var typeResult;
-		
-		switch (Context.follow (Context.getLocalType ())) {
-			
-			case TInst (_, [ Context.follow (_) => TFun (args, result) ]):
-				
-				typeArgs = args;
-				typeResult = result;
-			
-			case TInst (localType, _):
-				
-				Context.fatalError ("Invalid number of type parameters for " + localType.toString (), Context.currentPos ());
-				return null;
-			
-			default:
-				
-				throw false;
-			
-		}
-		
-		var typeParam = TFun (typeArgs, typeResult);
-		var typeString = "";
-		
-		if (typeArgs.length == 0) {
-			
-			typeString = "Void->";
-			
-		} else {
-			
-			for (arg in typeArgs) {
-				
-				typeString += arg.t.toString () + "->";
-				
-			}
-			
-		}
-		
-		typeString += typeResult.toString ();
-		typeString = StringTools.replace (typeString, "->", "_");
-		typeString = StringTools.replace (typeString, ".", "_");
-		typeString = StringTools.replace (typeString, "<", "_");
-		typeString = StringTools.replace (typeString, ">", "_");
-		
-		var name = "_Event_" + typeString;
-		
-		try {
-			
-			Context.getType ("lime.app." + name);
-			
-		} catch (e:Dynamic) {
-			
-			var pos = Context.currentPos ();
-			var fields = Context.getBuildFields ();
-			
-			var args:Array<FunctionArg> = [];
-			var argName, argNames = [];
-			
-			for (i in 0...typeArgs.length) {
-				
-				if (i == 0) {
-					
-					argName = "a";
-					
-				} else {
-					
-					argName = "a" + i;
-					
-				}
-				
-				argNames.push (Context.parse (argName, pos));
-				args.push ({ name: argName, type: typeArgs[i].t.toComplexType () });
-				
-			}
-			
-			var dispatch = macro {
-				
-				canceled = false;
-				
-				var listeners = __listeners;
-				var repeat = __repeat;
-				var i = 0;
-				
-				while (i < listeners.length) {
-					
-					listeners[i] ($a{argNames});
-					
-					if (!repeat[i]) {
-						
-						this.remove (cast listeners[i]);
-						
-					} else {
-						
-						i++;
-						
-					}
-					
-					if (canceled) {
-						
-						break;
-						
-					}
-					
-				}
-				
-			}
-			
-			var i = 0;
-			var field;
-			
-			while (i < fields.length) {
-				
-				field = fields[i];
-				
-				if (field.name == "__listeners" || field.name == "dispatch") {
-					
-					fields.remove (field);
-					
-				} else {
-					
-					i++;
-					
-				}
-				
-			}
-			
-			fields.push ( { name: "__listeners", access: [ APublic ], kind: FVar (TPath ({ pack: [], name: "Array", params: [ TPType (typeParam.toComplexType ()) ] })), pos: pos } );
-			fields.push ( { name: "dispatch", access: [ APublic ], kind: FFun ( { args: args, expr: dispatch, params: [], ret: macro :Void } ), pos: pos } );
-			
-			Context.defineType ({
-				
-				pos: pos,
-				pack: [ "lime", "app" ],
-				name: name,
-				kind: TDClass (),
-				fields: fields,
-				params: [ { name: "T" } ],
-				meta: [ { name: ":dox", params: [ macro hide ], pos: pos }, { name: ":noCompletion", pos: pos } ]
-				
-			});
-			
-		}
-		
-		return TPath ( { pack: [ "lime", "app" ], name: name, params: [ TPType (typeParam.toComplexType ()) ] } ).toType ();
-		
-	}
-	#end
-	
-	
-	public function cancel ():Void {
-		
+
+	public function cancel():Void {
 		canceled = true;
-		
 	}
-	
-	
-	public var dispatch:Dynamic;
-	
-	//macro public function dispatch (ethis:Expr, args:Array<Expr>):Void {
-		//
-		//return macro {
-			//
-			//var listeners = $ethis.listeners;
-			//var repeat = $ethis.repeat;
-			//var i = 0;
-			//
-			//while (i < listeners.length) {
-				//
-				//listeners[i] ($a{args});
-				//
-				//if (!repeat[i]) {
-					//
-					//$ethis.remove (listeners[i]);
-					//
-				//} else {
-					//
-					//i++;
-					//
-				//}
-				//
-			//}
-			//
-		//}
-		//
-	//}
-	
-	
-	public function has (listener:T):Bool {
-		
-		#if !macro
+
+	public function has(listener:T):Bool {
 		for (l in __listeners) {
-			
-			if (Reflect.compareMethods (l, listener)) return true;
-			
+			if (Reflect.compareMethods(l, listener))
+				return true;
 		}
-		#end
-		
 		return false;
-		
 	}
-	
-	
-	public function remove (listener:T):Void {
-		
-		#if !macro
+
+	public function remove(listener:T):Void {
 		var i = __listeners.length;
-		
+
 		while (--i >= 0) {
-			
-			if (Reflect.compareMethods (__listeners[i], listener)) {
-				
-				__listeners.splice (i, 1);
-				__priorities.splice (i, 1);
-				__repeat.splice (i, 1);
-				
+			if (Reflect.compareMethods(__listeners[i], listener)) {
+				__listeners.splice(i, 1);
+				__priorities.splice(i, 1);
 			}
-			
 		}
-		#end
-		
 	}
-	
-	
 }

--- a/src/lime/app/Future.hx
+++ b/src/lime/app/Future.hx
@@ -46,19 +46,6 @@ import lime.utils.Log;
 	}
 	
 	
-	public static function ofEvents<T> (onComplete:Event<T->Void>, onError:Event<Dynamic->Void> = null, onProgress:Event<Int->Int->Void> = null):Future<T> {
-		
-		var promise = new Promise<T> ();
-		
-		onComplete.add (function (data) promise.complete (data), true);
-		if (onError != null) onError.add (function (error) promise.error (error), true);
-		if (onProgress != null) onProgress.add (function (progress, total) promise.progress (progress, total), true);
-		
-		return promise.future;
-		
-	}
-	
-	
 	public function onComplete (listener:T->Void):Future<T> {
 		
 		if (listener != null) {

--- a/src/lime/app/Module.hx
+++ b/src/lime/app/Module.hx
@@ -54,7 +54,7 @@ class Module implements IModule {
 	@:noCompletion public function addWindow (window:Window):Void {
 		
 		window.onActivate.add (onWindowActivate.bind (window));
-		window.onClose.add (__onWindowClose.bind (window), false, -10000);
+		window.onClose.add (__onWindowClose.bind (window), -10000);
 		window.onCreate.add (onWindowCreate.bind (window));
 		window.onDeactivate.add (onWindowDeactivate.bind (window));
 		window.onDropFile.add (onWindowDropFile.bind (window));
@@ -92,7 +92,7 @@ class Module implements IModule {
 		
 		__application = application;
 		
-		application.onExit.add (onModuleExit, false, 0);
+		application.onExit.add (onModuleExit, 0);
 		application.onUpdate.add (update);
 		
 		for (gamepad in Gamepad.devices) {

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -235,7 +235,7 @@ class Stage extends DisplayObjectContainer implements IModule {
 		if (this.window != window) return;
 		
 		window.onActivate.add (onWindowActivate.bind (window));
-		window.onClose.add (onWindowClose.bind (window), false, -9000);
+		window.onClose.add (onWindowClose.bind (window), -9000);
 		window.onCreate.add (onWindowCreate.bind (window));
 		window.onDeactivate.add (onWindowDeactivate.bind (window));
 		window.onDropFile.add (onWindowDropFile.bind (window));
@@ -262,7 +262,7 @@ class Stage extends DisplayObjectContainer implements IModule {
 	
 	@:noCompletion public function registerModule (application:Application):Void {
 		
-		application.onExit.add (onModuleExit, false, 0);
+		application.onExit.add (onModuleExit, 0);
 		application.onUpdate.add (update);
 		
 		for (gamepad in Gamepad.devices) {


### PR DESCRIPTION
Instead of generating a full class per each listener argument combination we now just redirect to one of 4 possible Event subclasses for different number of arguments, specifying argument types as type parameters.

This saves quite some generated code, which is of course good. In general I think we should get rid of Event in most of the places and use direct function calls, because we don't need this kind of modularity here.

Oh, also removed the "listen once" functionality, because that's just the abuse of the observer pattern idea. Use a callback if you need to listen once.