### PR TITLE
use single temporary rectangle instance for bounds calculation

### DIFF
--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -96,13 +96,11 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 		
 		if (__bitmapData != null) {
 			
-			var bounds = Rectangle.__pool.get ();
+			var bounds = DisplayObject.__tempBoundsRectangle;
 			bounds.setTo (0, 0, __bitmapData.width, __bitmapData.height);
 			bounds.__transform (bounds, matrix);
 			
 			rect.__expand (bounds.x, bounds.y, bounds.width, bounds.height);
-			
-			Rectangle.__pool.release (bounds);
 			
 		}
 		

--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -97,9 +97,7 @@ class Bitmap extends DisplayObject implements IShaderDrawable {
 		if (__bitmapData != null) {
 			
 			var bounds = DisplayObject.__tempBoundsRectangle;
-			bounds.setTo (0, 0, __bitmapData.width, __bitmapData.height);
-			bounds.__transform (bounds, matrix);
-			
+			__bitmapData.rect.__transform (bounds, matrix);
 			rect.__expand (bounds.x, bounds.y, bounds.width, bounds.height);
 			
 		}

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -1795,10 +1795,9 @@ class BitmapData implements IBitmapDrawable {
 	
 	private function __getBounds (rect:Rectangle, matrix:Matrix):Void {
 		
-		var bounds = Rectangle.__pool.get ();
+		var bounds = DisplayObject.__tempBoundsRectangle;
 		this.rect.__transform (bounds, matrix);
 		rect.__expand (bounds.x, bounds.y, bounds.width, bounds.height);
-		Rectangle.__pool.release (bounds);
 		
 	}
 	

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -50,6 +50,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 	private static var __initStage:Stage;
 	private static var __instanceCount = 0;
 	private static var __tempStack = new ObjectPool<Vector<DisplayObject>> (function () { return new Vector<DisplayObject> (); }, function (stack) { stack.length = 0; });
+	private static var __tempBoundsRectangle = new Rectangle ();
 	
 	@:keep public var alpha (get, set):Float;
 	public var blendMode (get, set):BlendMode;
@@ -522,7 +523,8 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 		
 		if (__hasFilters ()) {
 			
-			var extension = Rectangle.__pool.get ();
+			var extension = DisplayObject.__tempBoundsRectangle;
+			extension.setEmpty ();
 			
 			for (filter in __filters) {
 				extension.__expand (-filter.__leftExtension, -filter.__topExtension, filter.__leftExtension + filter.__rightExtension, filter.__topExtension + filter.__bottomExtension);
@@ -532,8 +534,6 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 			rect.height += extension.height;
 			rect.x += extension.x;
 			rect.y += extension.y;
-			
-			Rectangle.__pool.release (extension);
 			
 		}
 		
@@ -572,11 +572,10 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 			
 		} else {
 			
-			var r = Rectangle.__pool.get ();
+			var r = DisplayObject.__tempBoundsRectangle;
 			r.copyFrom (__scrollRect);
 			r.__transform (r, matrix);
 			rect.__expand (matrix.tx, matrix.ty, r.width, r.height);
-			Rectangle.__pool.release (r);
 			
 		}
 		

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -573,8 +573,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 		} else {
 			
 			var r = DisplayObject.__tempBoundsRectangle;
-			r.copyFrom (__scrollRect);
-			r.__transform (r, matrix);
+			__scrollRect.__transform (r, matrix);
 			rect.__expand (matrix.tx, matrix.ty, r.width, r.height);
 			
 		}

--- a/src/openfl/display/Graphics.hx
+++ b/src/openfl/display/Graphics.hx
@@ -722,10 +722,9 @@ import js.html.CanvasRenderingContext2D;
 		
 		if (__bounds == null) return;
 		
-		var bounds = Rectangle.__pool.get ();
+		var bounds = DisplayObject.__tempBoundsRectangle;
 		__bounds.__transform (bounds, matrix);
 		rect.__expand (bounds.x, bounds.y, bounds.width, bounds.height);
-		Rectangle.__pool.release (bounds);
 		
 	}
 	

--- a/src/openfl/display/Tilemap.hx
+++ b/src/openfl/display/Tilemap.hx
@@ -286,13 +286,11 @@ class Tilemap extends #if !flash DisplayObject #else Bitmap implements IDisplayO
 	#if !flash
 	private override function __getBounds (rect:Rectangle, matrix:Matrix):Void {
 		
-		var bounds = Rectangle.__pool.get ();
+		var bounds = DisplayObject.__tempBoundsRectangle;
 		bounds.setTo (0, 0, __width, __height);
 		bounds.__transform (bounds, matrix);
 		
 		rect.__expand (bounds.x, bounds.y, bounds.width, bounds.height);
-		
-		Rectangle.__pool.release (bounds);
 		
 	}
 	#end

--- a/src/openfl/media/Video.hx
+++ b/src/openfl/media/Video.hx
@@ -103,13 +103,11 @@ class Video extends DisplayObject implements IShaderDrawable {
 	
 	private override function __getBounds (rect:Rectangle, matrix:Matrix):Void {
 		
-		var bounds = Rectangle.__pool.get ();
+		var bounds = DisplayObject.__tempBoundsRectangle;
 		bounds.setTo (0, 0, __width, __height);
 		bounds.__transform (bounds, matrix);
 		
 		rect.__expand (bounds.x, bounds.y, bounds.width, bounds.height);
-		
-		Rectangle.__pool.release (bounds);
 		
 	}
 	

--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -985,15 +985,13 @@ class TextField extends InteractiveObject implements IShaderDrawable {
 		
 		__updateLayout ();
 		
-		var bounds = Rectangle.__pool.get ();
+		var bounds = DisplayObject.__tempBoundsRectangle;
 		bounds.copyFrom (__textEngine.bounds);
 		bounds.x += __offsetX;
 		bounds.y += __offsetY;
 		bounds.__transform (bounds, matrix);
 		
 		rect.__expand (bounds.x, bounds.y, bounds.width, bounds.height);
-		
-		Rectangle.__pool.release (bounds);
 		
 	}
 	


### PR DESCRIPTION
instead of messing with the pool
