### PR TITLE
rework __ensureCaretVisible to subscribe to next ENTER_FRAME instead of using __enterFrame

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -109,7 +109,6 @@ class TextField extends InteractiveObject {
 	private var __textEngine:TextEngine;
 	private var __textFormat:TextFormat;
 	private var __forceCachedBitmapUpdate:Bool = false;
-	private var __ensureCaretVisibleNeeded = false;
 	
 	#if (js && html5)
 	private var __div:DivElement;
@@ -1205,17 +1204,6 @@ class TextField extends InteractiveObject {
 	}
 	
 	
-	override function __enterFrame(deltaTime:Int) {
-		
-		if (__ensureCaretVisibleNeeded) {
-			
-			__doEnsureCaretVisible ();
-			
-		}
-		
-	}
-	
-	
 	private override function __renderCanvas (renderSession:RenderSession):Void {
 		
 		#if (js && html5)
@@ -1365,16 +1353,20 @@ class TextField extends InteractiveObject {
 		
 	}
 	
-	inline function __ensureCaretVisible () {
+	function __ensureCaretVisible () {
 		
-		__ensureCaretVisibleNeeded = true;
+		if (!hasEventListener (Event.ENTER_FRAME)) {
+			
+			addEventListener (Event.ENTER_FRAME, __doEnsureCaretVisible);
+			
+		}
 		
 	}
 	
 	
-	private function __doEnsureCaretVisible () {
+	private function __doEnsureCaretVisible (_:Event) {
 		
-		__ensureCaretVisibleNeeded = false;
+		removeEventListener (Event.ENTER_FRAME, __doEnsureCaretVisible);
 		
 		__updateLayout ();
 		
@@ -2486,7 +2478,7 @@ class TextField extends InteractiveObject {
 		
 		// remove delayed __ensureCaretVisible calls, that could be added by the focus-in event before,
 		// because we changed the caret index and it's known to be within the visible area
-		__ensureCaretVisibleNeeded = false;
+		if (hasEventListener (Event.ENTER_FRAME)) removeEventListener (Event.ENTER_FRAME, __doEnsureCaretVisible);
 		
 		__dirty = true;
 		__setRenderDirty ();


### PR DESCRIPTION
i kind of like it less, because event subscribing is heavier, but I guess it's a fair price to pay to get rid of __enterFrame traversal,
and we can think of some more lightweight way for objects to register themselves for next-frame update if this turns out to be a problem