### PR TITLE
Rework Bitmap+BitmapData dirty checking and remove __enterFrame

### DIFF
--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -77,17 +77,24 @@ class Bitmap extends DisplayObject {
 		
 	}
 	
-	private override function __enterFrame (deltaTime:Int):Void {
+	override function __checkRenderDirty ():Bool {
 		
-		if (__bitmapData != null && __bitmapData.image != null) {
+		if (__renderDirty) {
+			
+			return true;
+			
+		} else if (__bitmapData != null) {
 			
 			var image = __bitmapData.image;
-			if (__bitmapData.image.version != __imageVersion) {
-				__setRenderDirty ();
+			if (image != null && image.version != __imageVersion) {
+				__renderDirty = true;
 				__imageVersion = image.version;
+				return true;
 			}
 			
 		}
+		
+		return false;
 		
 	}
 	
@@ -194,6 +201,9 @@ class Bitmap extends DisplayObject {
 			bitmapData.__fillBatchQuad (transform, __batchQuad.vertexData);
 			__batchQuad.texture = __bitmapData.getTexture (renderSession.gl);
 			__batchQuadDirty = false;
+		} else if (__checkRenderDirty()) {
+			__batchQuad.texture = __bitmapData.getTexture (renderSession.gl);
+			
 		}
 		
 		__batchQuad.setup(__worldAlpha, __worldColorTransform, BatcherBlendMode.fromOpenFLBlendMode(__worldBlendMode), smoothing);

--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -79,15 +79,14 @@ class Bitmap extends DisplayObject {
 	
 	override function __checkRenderDirty ():Bool {
 		
-		if (__renderDirty) {
+/* 		if (__renderDirty) {
 			
 			return true;
 			
-		} else if (__bitmapData != null) {
+		} else  */if (__bitmapData != null) {
 			
 			var image = __bitmapData.image;
 			if (image != null && image.version != __imageVersion) {
-				__renderDirty = true;
 				__imageVersion = image.version;
 				return true;
 			}
@@ -199,12 +198,13 @@ class Bitmap extends DisplayObject {
 			var snapToPixel = renderSession.roundPixels || __snapToPixel ();
 			var transform = renderSession.renderer.getDisplayTransformTempMatrix (__renderTransform, snapToPixel);
 			bitmapData.__fillBatchQuad (transform, __batchQuad.vertexData);
-			__batchQuad.texture = __bitmapData.getTexture (renderSession.gl);
+			// __batchQuad.texture = __bitmapData.getTexture (renderSession.gl);
 			__batchQuadDirty = false;
-		} else if (__checkRenderDirty()) {
-			__batchQuad.texture = __bitmapData.getTexture (renderSession.gl);
-			
 		}
+		// } else if (__checkRenderDirty()) {
+		__batchQuad.texture = __bitmapData.getTexture (renderSession.gl);
+			// 
+		// }
 		
 		__batchQuad.setup(__worldAlpha, __worldColorTransform, BatcherBlendMode.fromOpenFLBlendMode(__worldBlendMode), smoothing);
 		

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -87,7 +87,6 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 	private var __cacheBitmapColorTransform:ColorTransform;
 	private var __cacheBitmapData:BitmapData;
 	private var __cacheBitmapRender:Bool;
-	private var __children:Array<DisplayObject>;
 	private var __filters:Array<BitmapFilter>;
 	private var __graphics:Graphics;
 	private var __isMask:Bool;
@@ -464,13 +463,6 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 		event.eventPhase = AT_TARGET;
 		
 		return __dispatchEvent (event);
-		
-	}
-	
-	
-	private function __enterFrame (deltaTime:Int):Void {
-		
-		
 		
 	}
 	
@@ -1135,24 +1127,31 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 	
 	private function __cacheBitmapNeedsRender ():Bool {
 		return
-			(
-				__renderDirty
-				&& 
-				(
-					(__children != null && __children.length > 0) // TODO: this is the only place we use __children in DisplayObject, we can probably move this check in a DisplayObjectContainer override along with __children
-					||
-					(__graphics != null && __graphics.__dirty) // TODO: not sure if this ever holds, because graphics dirty flag is reset before we end up here
-				)
-			)
+			__checkRenderDirty ()
 			||
 			opaqueBackground != __cacheBitmapBackground
 			||
 			!__cacheBitmapColorTransform.__equals (__worldColorTransform);
 	}
-
-
+	
+	
+	function __checkRenderDirty ():Bool {
+		
+		return __renderDirty && __isGraphicsDirty ();
+		
+	}
+	
+	
+	inline function __isGraphicsDirty () {
+		
+		// TODO: not sure if this ever holds, because graphics dirty flag is reset before we end up here
+		return (__graphics != null && __graphics.__dirty);
+		
+	}
+	
+	
 	private function __renderToBitmap (renderSession:RenderSession, matrix:Matrix) {
-
+		
 		var cacheIsMask = __isMask;
 		var cacheVisible = __visible;
 		var cacheRenderable = __renderable;

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -820,10 +820,7 @@ class DisplayObjectContainer extends InteractiveObject {
 		
 		for (child in __children) {
 			
-			if (child.__checkRenderDirty ()) {
-				
-				// mark ourselves dirty to prevent recursion next time
-				__renderDirty = true;
+			if (child.__renderable && child.__worldAlpha > 0 && child.__checkRenderDirty ()) {
 				
 				return true;
 				

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -34,6 +34,7 @@ class DisplayObjectContainer extends InteractiveObject {
 	public var numChildren (get, never):Int;
 	public var tabChildren:Bool;
 	
+	private var __children:Array<DisplayObject>;
 	private var __removedChildren:Vector<DisplayObject>;
 	private var __updateTraverse:Bool;
 	
@@ -404,17 +405,6 @@ class DisplayObjectContainer extends InteractiveObject {
 				child.__dispatchChildren (event);
 				
 			}
-			
-		}
-		
-	}
-	
-	
-	private override function __enterFrame (deltaTime:Int):Void {
-		
-		for (child in __children) {
-			
-			child.__enterFrame (deltaTime);
 			
 		}
 		
@@ -816,6 +806,32 @@ class DisplayObjectContainer extends InteractiveObject {
 			}
 			
 		}
+		
+	}
+	
+	
+	override function __checkRenderDirty():Bool {
+		
+		if (__renderDirty) {
+			
+			return __children.length > 0 || __isGraphicsDirty ();
+			
+		}
+		
+		for (child in __children) {
+			
+			if (child.__checkRenderDirty ()) {
+				
+				// mark ourselves dirty to prevent recursion next time
+				__renderDirty = true;
+				
+				return true;
+				
+			}
+			
+		}
+		
+		return false;
 		
 	}
 	

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -92,7 +92,6 @@ class Stage extends DisplayObjectContainer {
 	private var __colorSplit:Array<Float>;
 	private var __colorString:String;
 	private var __contentsScaleFactor:Float;
-	private var __deltaTime:Int;
 	private var __displayMatrix:Matrix;
 	private var __displayState:StageDisplayState;
 	private var __dragBounds:Rectangle;
@@ -138,7 +137,6 @@ class Stage extends DisplayObjectContainer {
 		this.name = null;
 		
 		__contentsScaleFactor = window.scale;
-		__deltaTime = 0;
 		__displayState = NORMAL;
 		__mouseX = 0;
 		__mouseY = 0;
@@ -578,8 +576,6 @@ class Stage extends DisplayObjectContainer {
 	
 	@:noCompletion public function __onFrame (deltaTime:Int):Void {
 		
-		__deltaTime = deltaTime;
-		
 		dispatchPendingMouseMove ();
 
 		if (__rendering) return;
@@ -621,11 +617,9 @@ class Stage extends DisplayObjectContainer {
 		
 		__renderable = true;
 		
-		__enterFrame (__deltaTime);
-		__deltaTime = 0;
 		__traverse ();
 		
-		if (__renderer != null #if !openfl_always_render && __renderDirty #end) {
+		if (__renderer != null) {
 			
 			if (!Stage3D.__active) {
 				


### PR DESCRIPTION
Now instead of traversing the whole tree to check and mark Bitmaps with modified BitmapDatas, we explicitly check a subtree we're trying to render. We also only do this for cacheAsBitmap'd object, because for the GL rendering we don't care about the __renderDirty flags at all (tho we do the modification check in Bitmap.__getBatchQuad, although I'm not sure if this is any better than just always calling getTexture, because it will check the version again).