### PR TITLE
yet another take on removing __enterFrame

### DIFF
--- a/src/openfl/_internal/utils/PerlinNoise.hx
+++ b/src/openfl/_internal/utils/PerlinNoise.hx
@@ -193,7 +193,7 @@ class PerlinNoise {
 
         var color = Std.int( ( s * fPersMax + 1 ) * 128 );
 
-        bitmap.setPixel32( px, py, 0xff000000 | color << 16 | color << 8 | color );
+        bitmap.image.setPixel32( px, py, 0xff000000 | color << 16 | color << 8 | color, ARGB32 );
 
         _x += baseFactor;
       }

--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -41,7 +41,6 @@ class Bitmap extends DisplayObject {
 	private var __bitmapData:BitmapData;
 	private var __bitmapDataUserPrev:Bitmap;
 	private var __bitmapDataUserNext:Bitmap;
-	private var __imageVersion:Int;
 	
 	var __batchQuad:Quad;
 	var __batchQuadDirty:Bool = true;
@@ -90,16 +89,6 @@ class Bitmap extends DisplayObject {
 		}
 		
 	}
-	
-	inline function __syncImageVersion (version:Int) {
-		
-		if (__imageVersion != version) {
-			__setRenderDirty ();
-			__imageVersion = version;
-		}
-		
-	}
-	
 	
 	private override function __getBounds (rect:Rectangle, matrix:Matrix):Void {
 		
@@ -330,8 +319,6 @@ class Bitmap extends DisplayObject {
 			//__updateFilters = true;
 			
 		}
-		
-		__imageVersion = -1;
 		
 		return __bitmapData;
 		

--- a/src/openfl/display/Bitmap.hx
+++ b/src/openfl/display/Bitmap.hx
@@ -301,6 +301,14 @@ class Bitmap extends DisplayObject {
 	}
 	
 	
+	inline function __setBitmapDataDirty () {
+		
+		__batchQuadDirty = true;
+		__setRenderDirty ();
+		
+	}
+	
+	
 	private function set_bitmapData (value:BitmapData):BitmapData {
 		
 		if (stage != null && value != __bitmapData) {
@@ -311,8 +319,7 @@ class Bitmap extends DisplayObject {
 		__bitmapData = value;
 		smoothing = false;
 		
-		__setRenderDirty ();
-		__batchQuadDirty = true;
+		__setBitmapDataDirty ();
 		
 		if (__hasFilters ()) {
 			

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -85,6 +85,9 @@ class BitmapData implements IBitmapDrawable {
 	private var __vaoMask:GLVertexArrayObject;
 	private var __vaoContext: IVertexArrayObjectContext;
 	
+	var __usersHead:Bitmap;
+	var __usersTail:Bitmap;
+	
 	public function new (width:Int, height:Int, transparent:Bool = true, fillColor:UInt = 0xFFFFFFFF) {
 		
 		this.transparent = transparent;
@@ -171,6 +174,18 @@ class BitmapData implements IBitmapDrawable {
 		
 		image.colorTransform (rect.__toLimeRectangle (), colorTransform.__toLimeColorMatrix ());
 		
+		__markUsersRenderDirty ();
+		
+	}
+	
+	
+	function __markUsersRenderDirty () {
+		var version = image.version;
+		var user = __usersHead;
+		while (user != null) {
+			user.__syncImageVersion(version);
+			user = user.__bitmapDataUserNext;
+		}
 	}
 	
 	

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -180,10 +180,9 @@ class BitmapData implements IBitmapDrawable {
 	
 	
 	function __markUsersRenderDirty () {
-		var version = image.version;
 		var user = __usersHead;
 		while (user != null) {
-			user.__syncImageVersion(version);
+			user.__setRenderDirty ();
 			user = user.__bitmapDataUserNext;
 		}
 	}

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -80,6 +80,7 @@ class BitmapData implements IBitmapDrawable {
 	private var __textureVersion:Int;
 	private var __ownsTexture:Bool;
 	private var __transform:Matrix;
+	private var __lock:LockState;
 	
 	private var __vao:GLVertexArrayObject;
 	private var __vaoMask:GLVertexArrayObject;
@@ -98,6 +99,8 @@ class BitmapData implements IBitmapDrawable {
 		this.width = width;
 		this.height = height;
 		rect = new Rectangle (0, 0, width, height);
+
+		__lock = Unlocked;
 		
 		if (width > 0 && height > 0) {
 			
@@ -135,6 +138,8 @@ class BitmapData implements IBitmapDrawable {
 		if (!readable || sourceBitmapData == null || !sourceBitmapData.readable) return;
 		
 		filter.__applyFilter (this, sourceBitmapData, sourceRect, destPoint);
+		
+		__markUsersRenderDirty ();
 		
 	}
 	
@@ -179,7 +184,15 @@ class BitmapData implements IBitmapDrawable {
 	}
 	
 	
-	function __markUsersRenderDirty () {
+	inline function __markUsersRenderDirty () {
+		if (__lock == Unlocked)  {
+			__doMarkUsersRenderDirty();
+		} else {
+			__lock = Modified;
+		}
+	}
+	
+	function __doMarkUsersRenderDirty () {
 		var user = __usersHead;
 		while (user != null) {
 			user.__setBitmapDataDirty ();
@@ -295,7 +308,7 @@ class BitmapData implements IBitmapDrawable {
 						
 					}
 					
-					bitmapData.setPixel32 (x, y, comparePixel);
+					bitmapData.image.setPixel32 (x, y, comparePixel, ARGB32);
 					
 				}
 				
@@ -340,6 +353,8 @@ class BitmapData implements IBitmapDrawable {
 		
 		image.copyChannel (sourceBitmapData.image, sourceRect.__toLimeRectangle (), destPoint.__toLimeVector2 (), sourceChannel, destChannel);
 		
+		__markUsersRenderDirty ();
+		
 	}
 	
 	
@@ -356,6 +371,8 @@ class BitmapData implements IBitmapDrawable {
 		
 		image.copyPixels (sourceBitmapData.image, sourceRect.__toLimeRectangle (), destPoint.__toLimeVector2 (), alphaBitmapData != null ? alphaBitmapData.image : null, alphaPoint != null ? __tempVector : null, mergeAlpha);
 		
+		__markUsersRenderDirty ();
+		
 	}
 	
 	
@@ -371,6 +388,15 @@ class BitmapData implements IBitmapDrawable {
 		
 		__isValid = false;
 		readable = false;
+		
+		// unlink all the users TODO: prevent re-linking disposed BitmapData's (check __isValid?)
+		var user = __usersHead;
+		while (user != null) {
+			var next = user.__bitmapDataUserNext;
+			user.__bitmapDataUserPrev = user.__bitmapDataUserNext = null;
+			user = next;
+		}
+		__usersHead = __usersTail = null;
 		
 		if (__buffer != null) {
 			if (__bufferContext.isBuffer (__buffer)) { // prevent the warning when the id becomes invalid after context loss+restore
@@ -438,6 +464,8 @@ class BitmapData implements IBitmapDrawable {
 		
 		__draw (source, matrix, blendMode, clipRect, smoothing, false);
 		
+		__markUsersRenderDirty ();
+		
 	}
 	
 	
@@ -501,6 +529,8 @@ class BitmapData implements IBitmapDrawable {
 			
 			image.fillRect (rect.__toLimeRectangle (), color, ARGB32);
 			
+			__markUsersRenderDirty ();
+			
 		}
 		
 	}
@@ -510,6 +540,7 @@ class BitmapData implements IBitmapDrawable {
 		
 		if (!readable) return;
 		image.floodFill (x, y, color, ARGB32);
+		__markUsersRenderDirty ();
 		
 	}
 	
@@ -1194,7 +1225,9 @@ class BitmapData implements IBitmapDrawable {
 	
 	public function lock ():Void {
 		
-		
+		if (__lock == Unlocked) {
+			__lock = Locked;
+		}
 		
 	}
 	
@@ -1203,6 +1236,7 @@ class BitmapData implements IBitmapDrawable {
 		
 		if (!readable || sourceBitmapData == null || !sourceBitmapData.readable || sourceRect == null || destPoint == null) return;
 		image.merge (sourceBitmapData.image, sourceRect.__toLimeRectangle (), destPoint.__toLimeVector2 (), redMultiplier, greenMultiplier, blueMultiplier, alphaMultiplier);
+		__markUsersRenderDirty ();
 		
 	}
 	
@@ -1258,9 +1292,10 @@ class BitmapData implements IBitmapDrawable {
 				rgb = (rgb << 8) + green;
 				rgb = (rgb << 8) + blue;
 				
-				setPixel32(x, y, rgb);
+				image.setPixel32 (x, y, rgb, ARGB32);
 			}
 		}
+		__markUsersRenderDirty ();
 		
 	}
 	
@@ -1304,6 +1339,7 @@ class BitmapData implements IBitmapDrawable {
 		if (!readable) return;
 		var noise = new PerlinNoise (randomSeed, numOctaves, 0.01);
 		noise.fill (this, baseX, baseY, 0);
+		__markUsersRenderDirty ();
 		
 	}
 	
@@ -1312,6 +1348,7 @@ class BitmapData implements IBitmapDrawable {
 		
 		if (!readable) return;
 		image.scroll (x, y);
+		__markUsersRenderDirty ();
 		
 	}
 	
@@ -1320,6 +1357,7 @@ class BitmapData implements IBitmapDrawable {
 		
 		if (!readable) return;
 		image.setPixel (x, y, color, ARGB32);
+		__markUsersRenderDirty ();
 		
 	}
 	
@@ -1328,6 +1366,7 @@ class BitmapData implements IBitmapDrawable {
 		
 		if (!readable) return;
 		image.setPixel32 (x, y, color, ARGB32);
+		__markUsersRenderDirty ();
 		
 	}
 	
@@ -1340,6 +1379,7 @@ class BitmapData implements IBitmapDrawable {
 		if (byteArray.bytesAvailable < length) throw new Error ("End of file was encountered.", 2030);
 		
 		image.setPixels (rect.__toLimeRectangle (), byteArray, byteArray.position, ARGB32, byteArray.endian);
+		__markUsersRenderDirty ();
 		
 	}
 	
@@ -1372,7 +1412,10 @@ class BitmapData implements IBitmapDrawable {
 	
 	public function unlock (changeRect:Rectangle = null):Void {
 		
-		
+		if (__lock == Modified) {
+			__doMarkUsersRenderDirty ();
+		}
+		__lock = Unlocked;
 		
 	}
 	
@@ -1648,4 +1691,11 @@ class BitmapData implements IBitmapDrawable {
 	var u3:Float;
 	var v3:Float;
 	function new() {}
+}
+
+
+private enum abstract LockState(Int) {
+	var Unlocked;
+	var Locked;
+	var Modified;
 }

--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -182,7 +182,7 @@ class BitmapData implements IBitmapDrawable {
 	function __markUsersRenderDirty () {
 		var user = __usersHead;
 		while (user != null) {
-			user.__setRenderDirty ();
+			user.__setBitmapDataDirty ();
 			user = user.__bitmapDataUserNext;
 		}
 	}

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -468,13 +468,6 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 	}
 	
 	
-	private function __enterFrame (deltaTime:Int):Void {
-		
-		
-		
-	}
-	
-	
 	private function __forceRenderDirty ():Void {
 		
 		__renderDirty = true;

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -106,7 +106,7 @@ class DisplayObjectContainer extends InteractiveObject {
 			
 			if (addedToStage) {
 				
-				this.__setStageReference (stage);
+				child.__setStageReference (stage);
 				
 			}
 			

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -410,17 +410,6 @@ class DisplayObjectContainer extends InteractiveObject {
 	}
 	
 	
-	private override function __enterFrame (deltaTime:Int):Void {
-		
-		for (child in __children) {
-			
-			child.__enterFrame (deltaTime);
-			
-		}
-		
-	}
-	
-	
 	private override function __forceRenderDirty ():Void {
 		
 		super.__forceRenderDirty();

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -92,7 +92,6 @@ class Stage extends DisplayObjectContainer {
 	private var __colorSplit:Array<Float>;
 	private var __colorString:String;
 	private var __contentsScaleFactor:Float;
-	private var __deltaTime:Int;
 	private var __displayMatrix:Matrix;
 	private var __displayState:StageDisplayState;
 	private var __dragBounds:Rectangle;
@@ -138,7 +137,6 @@ class Stage extends DisplayObjectContainer {
 		this.name = null;
 		
 		__contentsScaleFactor = window.scale;
-		__deltaTime = 0;
 		__displayState = NORMAL;
 		__mouseX = 0;
 		__mouseY = 0;
@@ -578,8 +576,6 @@ class Stage extends DisplayObjectContainer {
 	
 	@:noCompletion public function __onFrame (deltaTime:Int):Void {
 		
-		__deltaTime = deltaTime;
-		
 		dispatchPendingMouseMove ();
 
 		if (__rendering) return;
@@ -621,8 +617,6 @@ class Stage extends DisplayObjectContainer {
 		
 		__renderable = true;
 		
-		__enterFrame (__deltaTime);
-		__deltaTime = 0;
 		__traverse ();
 		
 		if (__renderer != null #if !openfl_always_render && __renderDirty #end) {


### PR DESCRIPTION
this time we try to link BitmapData objects to its "user" Bitmap objects that are on stage, so when we do a mutation on the BitmapData we can notify the Bitmaps and mark them dirty