### PR TITLE
Fix blendMode when drawing into a BitmapData

### DIFF
--- a/src/openfl/display/BitmapData.hx
+++ b/src/openfl/display/BitmapData.hx
@@ -462,6 +462,12 @@ class BitmapData implements IBitmapDrawable {
 			
 		}
 		
+		if (blendMode == null) {
+			
+			blendMode = NORMAL;
+			
+		}
+		
 		__draw (source, matrix, blendMode, clipRect, smoothing, false);
 		
 		__markUsersRenderDirty ();
@@ -1475,7 +1481,6 @@ class BitmapData implements IBitmapDrawable {
 		renderSession.pixelRatio = __pixelRatio;
 		renderSession.maskManager = new CanvasMaskManager (renderSession);
 		renderSession.blendModeManager = new CanvasBlendModeManager (renderSession);
-		renderSession.blendModeManager.setBlendMode(blendMode);
 		
 		buffer.__srcContext.save();
 		
@@ -1487,7 +1492,7 @@ class BitmapData implements IBitmapDrawable {
 			
 		}
 		
-		source.__renderToBitmap (renderSession, matrix);
+		source.__renderToBitmap (renderSession, matrix, blendMode);
 		
 		buffer.__srcContext.restore();
 		
@@ -1663,9 +1668,10 @@ class BitmapData implements IBitmapDrawable {
 	#end
 	
 	
-	private function __renderToBitmap (renderSession:RenderSession, matrix:Matrix) {
+	private function __renderToBitmap (renderSession:RenderSession, matrix:Matrix, blendMode:BlendMode) {
 		
 		renderSession.context.globalAlpha = 1;
+		renderSession.blendModeManager.setBlendMode (blendMode);
 		__drawToCanvas (renderSession.context, matrix, renderSession.roundPixels, renderSession.pixelRatio, null, false);
 		
 	}

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -1144,7 +1144,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 	}
 
 
-	private function __renderToBitmap (renderSession:RenderSession, matrix:Matrix) {
+	private function __renderToBitmap (renderSession:RenderSession, matrix:Matrix, blendMode:BlendMode) {
 
 		var cacheIsMask = __isMask;
 		var cacheVisible = __visible;
@@ -1161,7 +1161,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 		__visible = true;
 		__renderable = true;
 		__worldAlpha = 1;
-		__worldBlendMode = NORMAL;
+		__worldBlendMode = blendMode;
 		__worldTransform.copyFrom (matrix);
 		__renderTransform.copyFrom (matrix);
 		__adjustRenderTransform ();

--- a/src/openfl/display/IBitmapDrawable.hx
+++ b/src/openfl/display/IBitmapDrawable.hx
@@ -11,6 +11,6 @@ interface IBitmapDrawable {
 	private var __transform:Matrix;
 	
 	private function __getBounds (rect:Rectangle, matrix:Matrix):Void;
-	private function __renderToBitmap (RenderSession:RenderSession, matrix:Matrix):Void;
+	private function __renderToBitmap (renderSession:RenderSession, matrix:Matrix, blendMode:BlendMode):Void;
 	
 }


### PR DESCRIPTION
Just calling `setBlendMode` won't work because it'll be set back to `__worldBlendMode` by `__renderCanvas` later. So instead pass the given `blendMode` as `__worldBlendMode` of the drawn root object.