### PR TITLE
(hopefully) fix text format ranges recalculation when replacing text

### DIFF
--- a/src/openfl/text/TextField.hx
+++ b/src/openfl/text/TextField.hx
@@ -535,7 +535,6 @@ class TextField extends InteractiveObject {
 		if (endIndex < beginIndex || beginIndex < 0 || endIndex > __text.length || newText == null) return;
 		
 		__updateText (__text.substring (0, beginIndex) + newText + __text.substring (endIndex));
-		if (endIndex > __text.length) endIndex = __text.length;
 		
 		var offset = newText.length - (endIndex - beginIndex);
 		


### PR DESCRIPTION
not sure if it's 100% correct because it's quite hard to think about all the possible cases here and we don't have a good test case anywhere (because this is about editable fields with multiple text formats), but the logic of the change looks correct to me, as we do not want to clamp the endIndex, because:
a) the "offset" should be negative when we remove text
b) the ranges' start/end refer to the old text, so the checks should be against the old indices

I'm almost sure there are more bugs with the text format ranges to discover, but oh well, let's deal with this if/when we have a case with multiple formats.
Also this code is different in the current upstream OpenFL, but I _think_ it's still buggy there, because the clamping is still there.