### PR TITLE
do not canvas-render objects under scaled-to-zero masks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-	"files.trimTrailingWhitespace": false
+	"files.trimTrailingWhitespace": true
 }

--- a/src/openfl/_internal/renderer/canvas/CanvasBitmap.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasBitmap.hx
@@ -13,18 +13,20 @@ class CanvasBitmap {
 
 		if (bitmap.__bitmapData != null && bitmap.__bitmapData.__isValid && bitmap.__bitmapData.__canBeDrawnToCanvas()) {
 			renderSession.blendModeManager.setBlendMode(bitmap.__worldBlendMode);
-			renderSession.maskManager.pushObject(bitmap, false);
 
-			if (!renderSession.allowSmoothing || !bitmap.smoothing) {
-				CanvasSmoothing.setEnabled(context, false);
-			}
+			var needRender = renderSession.maskManager.pushObject(bitmap, false);
+			if (needRender) {
+				if (!renderSession.allowSmoothing || !bitmap.smoothing) {
+					CanvasSmoothing.setEnabled(context, false);
+				}
 
-			context.globalAlpha = bitmap.__worldAlpha;
-			bitmap.__bitmapData.__drawToCanvas(context, bitmap.__renderTransform, renderSession.roundPixels || bitmap.__snapToPixel(),
-				renderSession.pixelRatio, bitmap.__scrollRect, true);
+				context.globalAlpha = bitmap.__worldAlpha;
+				bitmap.__bitmapData.__drawToCanvas(context, bitmap.__renderTransform, renderSession.roundPixels || bitmap.__snapToPixel(),
+					renderSession.pixelRatio, bitmap.__scrollRect, true);
 
-			if (!renderSession.allowSmoothing || !bitmap.smoothing) {
-				CanvasSmoothing.setEnabled(context, true);
+				if (!renderSession.allowSmoothing || !bitmap.smoothing) {
+					CanvasSmoothing.setEnabled(context, true);
+				}
 			}
 
 			renderSession.maskManager.popObject(bitmap, false);

--- a/src/openfl/_internal/renderer/canvas/CanvasDisplayObject.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasDisplayObject.hx
@@ -17,23 +17,25 @@ class CanvasDisplayObject {
 			&& displayObject.width > 0
 			&& displayObject.height > 0) {
 			renderSession.blendModeManager.setBlendMode(displayObject.__worldBlendMode);
-			renderSession.maskManager.pushObject(displayObject);
 
-			var context = renderSession.context;
-			var transform = displayObject.__renderTransform;
-			var pixelRatio = renderSession.pixelRatio;
+			var needRender = renderSession.maskManager.pushObject(displayObject);
+			if (needRender) {
+				var context = renderSession.context;
+				var transform = displayObject.__renderTransform;
+				var pixelRatio = renderSession.pixelRatio;
 
-			if (renderSession.roundPixels) {
-				context.setTransform(transform.a * pixelRatio, transform.b, transform.c, transform.d * pixelRatio, Math.round(transform.tx * pixelRatio),
-					Math.round(transform.ty * pixelRatio));
-			} else {
-				context.setTransform(transform.a * pixelRatio, transform.b, transform.c, transform.d * pixelRatio, transform.tx * pixelRatio,
-					transform.ty * pixelRatio);
+				if (renderSession.roundPixels) {
+					context.setTransform(transform.a * pixelRatio, transform.b, transform.c, transform.d * pixelRatio, Math.round(transform.tx * pixelRatio),
+						Math.round(transform.ty * pixelRatio));
+				} else {
+					context.setTransform(transform.a * pixelRatio, transform.b, transform.c, transform.d * pixelRatio, transform.tx * pixelRatio,
+						transform.ty * pixelRatio);
+				}
+
+				var color:ARGB = (displayObject.opaqueBackground : ARGB);
+				context.fillStyle = 'rgb(${color.r},${color.g},${color.b})';
+				context.fillRect(0, 0, displayObject.width, displayObject.height);
 			}
-
-			var color:ARGB = (displayObject.opaqueBackground : ARGB);
-			context.fillStyle = 'rgb(${color.r},${color.g},${color.b})';
-			context.fillRect(0, 0, displayObject.width, displayObject.height);
 
 			renderSession.maskManager.popObject(displayObject);
 		}

--- a/src/openfl/_internal/renderer/canvas/CanvasMaskManager.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasMaskManager.hx
@@ -10,7 +10,11 @@ class CanvasMaskManager {
 		this.renderSession = renderSession;
 	}
 
-	function pushMask(mask:DisplayObject) {
+	function pushMask(mask:DisplayObject):Bool {
+		if (mask.__isScaledToZero()) {
+			return false;
+		}
+
 		var context = renderSession.context;
 
 		context.save();
@@ -27,16 +31,20 @@ class CanvasMaskManager {
 		context.clip();
 
 		// mask.worldAlpha = cacheAlpha;
+
+		return true;
 	}
 
-	public function pushObject(object:DisplayObject, handleScrollRect:Bool = true) {
+	public function pushObject(object:DisplayObject, handleScrollRect:Bool = true):Bool {
 		if (handleScrollRect && object.__scrollRect != null) {
 			pushRect(object.__scrollRect, object.__renderTransform);
 		}
 
 		if (!object.__cacheBitmapRender && object.__mask != null) {
-			pushMask(object.__mask);
+			return pushMask(object.__mask);
 		}
+
+		return true;
 	}
 
 	public function pushRect(rect:Rectangle, transform:Matrix) {

--- a/src/openfl/_internal/renderer/canvas/CanvasShape.hx
+++ b/src/openfl/_internal/renderer/canvas/CanvasShape.hx
@@ -25,23 +25,25 @@ class CanvasShape {
 
 				if (width > 0 && height > 0 && (scrollRect == null || (scrollRect.width > 0 && scrollRect.height > 0))) {
 					renderSession.blendModeManager.setBlendMode(shape.__worldBlendMode);
-					renderSession.maskManager.pushObject(shape);
 
-					context.globalAlpha = shape.__worldAlpha;
+					var needRender = renderSession.maskManager.pushObject(shape);
+					if (needRender) {
+						context.globalAlpha = shape.__worldAlpha;
 
-					var transform = graphics.__worldTransform;
-					var pixelRatio = renderSession.pixelRatio;
-					var scale = 1; // As opposed of CanvasBitmap, canvases have the same pixelRatio as display, therefore we don't need to scale them and so scale is always 1
+						var transform = graphics.__worldTransform;
+						var pixelRatio = renderSession.pixelRatio;
+						var scale = 1; // As opposed of CanvasBitmap, canvases have the same pixelRatio as display, therefore we don't need to scale them and so scale is always 1
 
-					if (renderSession.roundPixels) {
-						context.setTransform(transform.a * scale, transform.b, transform.c, transform.d * scale, Math.round(transform.tx * pixelRatio),
-							Math.round(transform.ty * pixelRatio));
-					} else {
-						context.setTransform(transform.a * scale, transform.b, transform.c, transform.d * scale, transform.tx * pixelRatio,
-							transform.ty * pixelRatio);
+						if (renderSession.roundPixels) {
+							context.setTransform(transform.a * scale, transform.b, transform.c, transform.d * scale, Math.round(transform.tx * pixelRatio),
+								Math.round(transform.ty * pixelRatio));
+						} else {
+							context.setTransform(transform.a * scale, transform.b, transform.c, transform.d * scale, transform.tx * pixelRatio,
+								transform.ty * pixelRatio);
+						}
+
+						context.drawImage(graphics.__canvas, 0, 0);
 					}
-
-					context.drawImage(graphics.__canvas, 0, 0);
 
 					renderSession.maskManager.popObject(shape);
 				}

--- a/src/openfl/display/DisplayObject.hx
+++ b/src/openfl/display/DisplayObject.hx
@@ -624,7 +624,7 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 		var renderParent:DisplayObject = parent;
 		if (__isMask && renderParent == null)
 			renderParent = __maskTarget;
-		__renderable = (visible && __scaleX != 0 && __scaleY != 0 && !__isMask && (renderParent == null || !renderParent.__isMask));
+		__renderable = (visible && !__isScaledToZero() && !__isMask && (renderParent == null || !renderParent.__isMask));
 		__updateTransforms();
 
 		if (!__worldColorTransform.__equals(transform.colorTransform)) {
@@ -649,6 +649,10 @@ class DisplayObject extends EventDispatcher implements IBitmapDrawable {
 		if (mask != null) {
 			mask.__update(resetUpdateDirty);
 		}
+	}
+
+	public inline function __isScaledToZero():Bool {
+		return __scaleX == 0 || __scaleY == 0;
 	}
 
 	private function __updateCacheBitmap(renderSession:RenderSession, force:Bool):Bool {

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -308,7 +308,7 @@ class DisplayObjectContainer extends InteractiveObject {
 		var childWorldTransform = Matrix.__pool.get();
 
 		for (child in __children) {
-			if (child.__scaleX == 0 || child.__scaleY == 0)
+			if (child.__isScaledToZero())
 				continue;
 
 			DisplayObject.__calculateAbsoluteTransform(child.__transform, matrix, childWorldTransform);
@@ -328,7 +328,7 @@ class DisplayObjectContainer extends InteractiveObject {
 		var childWorldTransform = Matrix.__pool.get();
 
 		for (child in __children) {
-			if (child.__scaleX == 0 || child.__scaleY == 0 || child.__isMask)
+			if (child.__isScaledToZero() || child.__isMask)
 				continue;
 
 			DisplayObject.__calculateAbsoluteTransform(child.__transform, matrix, childWorldTransform);
@@ -353,7 +353,7 @@ class DisplayObjectContainer extends InteractiveObject {
 		var childWorldTransform = Matrix.__pool.get();
 
 		for (child in __children) {
-			if (child.__scaleX == 0 || child.__scaleY == 0 || child.__isMask)
+			if (child.__isScaledToZero() || child.__isMask)
 				continue;
 
 			DisplayObject.__calculateAbsoluteTransform(child.__transform, matrix, childWorldTransform);
@@ -489,18 +489,23 @@ class DisplayObjectContainer extends InteractiveObject {
 		if (__cacheBitmap != null && !__cacheBitmapRender)
 			return;
 
-		renderSession.maskManager.pushObject(this);
+		var needRender = renderSession.maskManager.pushObject(this);
+		if (needRender) {
+			if (renderSession.clearRenderDirty) {
+				for (child in __children) {
+					child.__renderCanvas(renderSession);
+					child.__renderDirty = false;
+				}
 
-		if (renderSession.clearRenderDirty) {
-			for (child in __children) {
-				child.__renderCanvas(renderSession);
-				child.__renderDirty = false;
+				__renderDirty = false;
+			} else {
+				for (child in __children) {
+					child.__renderCanvas(renderSession);
+				}
 			}
-
-			__renderDirty = false;
-		} else {
+		} else if (renderSession.clearRenderDirty) {
 			for (child in __children) {
-				child.__renderCanvas(renderSession);
+				child.__renderDirty = false;
 			}
 		}
 

--- a/src/openfl/display/DisplayObjectContainer.hx
+++ b/src/openfl/display/DisplayObjectContainer.hx
@@ -507,6 +507,7 @@ class DisplayObjectContainer extends InteractiveObject {
 			for (child in __children) {
 				child.__renderDirty = false;
 			}
+			__renderDirty = false;
 		}
 
 		renderSession.maskManager.popObject(this);


### PR DESCRIPTION
because canvas clipping paths do not work for empty objects

technically we could also add this check to GL, but it's not worth the complication