### PR TITLE
Improve texture upload

### DIFF
--- a/src/openfl/_internal/stage3D/opengl/GLCubeTexture.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLCubeTexture.hx
@@ -1,6 +1,5 @@
 package openfl._internal.stage3D.opengl;
 
-import lime.graphics.GLRenderContext;
 import lime.graphics.opengl.GL;
 import lime.utils.ArrayBufferView;
 import lime.utils.UInt8Array;
@@ -41,11 +40,9 @@ class GLCubeTexture {
 				return;
 
 			hasTexture = true;
-			var target = __sideToTarget(side);
-
 			cubeTexture.__format = format;
 
-			gl.compressedTexImage2D(target, level, cubeTexture.__internalFormat, width, height, 0, bytes, 0, blockLength);
+			gl.compressedTexImage2D(__sideToTarget(side), level, cubeTexture.__internalFormat, width, height, 0, bytes, 0, blockLength);
 			GLUtils.checkGLError(gl);
 
 			// __trackCompressedMemoryUsage (blockLength);
@@ -66,6 +63,9 @@ class GLCubeTexture {
 
 	public static function uploadFromBitmapData(cubeTexture:CubeTexture, renderSession:GLRenderSession, source:BitmapData, side:UInt, miplevel:UInt = 0,
 			generateMipmap:Bool = false):Void {
+		if (source == null)
+			return;
+
 		var size = cubeTexture.__size >> miplevel;
 		if (size == 0)
 			return;
@@ -79,13 +79,12 @@ class GLCubeTexture {
 		// }
 
 		var image = cubeTexture.__getImage(source);
-
 		GLTextureBase.uploadFromImage(renderSession.gl, cubeTexture, image, miplevel, size, size, __sideToTarget(side));
 		cubeTexture.__uploadedSides |= 1 << side;
 	}
 
 	public static function uploadFromByteArray(cubeTexture:CubeTexture, renderSession:GLRenderSession, data:ByteArray, byteArrayOffset:UInt, side:UInt,
-			miplevel:UInt):Void {
+			miplevel:UInt = 0):Void {
 		#if js
 		if (byteArrayOffset == 0) {
 			uploadFromTypedArray(cubeTexture, renderSession, @:privateAccess (data : ByteArrayData).b, side, miplevel);
@@ -96,9 +95,11 @@ class GLCubeTexture {
 		uploadFromTypedArray(cubeTexture, renderSession, new UInt8Array(data.toArrayBuffer(), byteArrayOffset), side, miplevel);
 	}
 
-	public static function uploadFromTypedArray(cubeTexture:CubeTexture, renderSession:GLRenderSession, data:ArrayBufferView, side:UInt, miplevel:UInt):Void {
+	public static function uploadFromTypedArray(cubeTexture:CubeTexture, renderSession:GLRenderSession, data:ArrayBufferView, side:UInt,
+			miplevel:UInt = 0):Void {
 		if (data == null)
 			return;
+
 		var gl = renderSession.gl;
 
 		var size = cubeTexture.__size >> miplevel;

--- a/src/openfl/_internal/stage3D/opengl/GLCubeTexture.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLCubeTexture.hx
@@ -75,13 +75,11 @@ class GLCubeTexture {
 		if (size == 0)
 			return;
 
-		// if (source.width != size || source.height != size) {
-		//
-		// var copy = new BitmapData (size, size, true, 0);
-		// copy.draw (source);
-		// source = copy;
-		//
-		// }
+		if (source.width != size || source.height != size) {
+			var copy = new BitmapData(size, size, true, 0);
+			copy.draw(source);
+			source = copy;
+		}
 
 		var image = cubeTexture.__getImage(source);
 		GLTextureBase.uploadFromImage(renderSession.gl, cubeTexture, image, miplevel, size, size, __sideToTarget(side));

--- a/src/openfl/_internal/stage3D/opengl/GLCubeTexture.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLCubeTexture.hx
@@ -41,6 +41,7 @@ class GLCubeTexture {
 
 			hasTexture = true;
 			cubeTexture.__format = format;
+			cubeTexture.__internalFormat = format;
 
 			gl.compressedTexImage2D(__sideToTarget(side), level, cubeTexture.__internalFormat, width, height, 0, bytes, 0, blockLength);
 			GLUtils.checkGLError(gl);

--- a/src/openfl/_internal/stage3D/opengl/GLCubeTexture.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLCubeTexture.hx
@@ -46,6 +46,8 @@ class GLCubeTexture {
 			gl.compressedTexImage2D(__sideToTarget(side), level, cubeTexture.__internalFormat, width, height, 0, bytes, 0, blockLength);
 			GLUtils.checkGLError(gl);
 
+			cubeTexture.__uploadedSides |= 1 << side;
+
 			// __trackCompressedMemoryUsage (blockLength);
 		});
 
@@ -55,6 +57,8 @@ class GLCubeTexture {
 				gl.texImage2D(__sideToTarget(side), 0, cubeTexture.__internalFormat, cubeTexture.__size, cubeTexture.__size, 0, cubeTexture.__format,
 					GL.UNSIGNED_BYTE, data);
 				GLUtils.checkGLError(gl);
+
+				cubeTexture.__uploadedSides |= 1 << side;
 			}
 		}
 

--- a/src/openfl/_internal/stage3D/opengl/GLTexture.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLTexture.hx
@@ -69,17 +69,8 @@ class GLTexture {
 		GLUtils.checkGLError(gl);
 	}
 
-	public static function uploadFromBitmapData(texture:Texture, renderSession:GLRenderSession, source:BitmapData, miplevel:UInt, generateMipmap:Bool):Void {
-		/* TODO
-			if (LowMemoryMode) {
-				// shrink bitmap data
-				source = source.shrinkToHalfResolution();
-				// shrink our dimensions for upload
-				width = source.width;
-				height = source.height;
-			}
-		 */
-
+	public static function uploadFromBitmapData(texture:Texture, renderSession:GLRenderSession, source:BitmapData, miplevel:UInt = 0,
+			generateMipmap:Bool = false):Void {
 		if (source == null)
 			return;
 
@@ -118,6 +109,7 @@ class GLTexture {
 	public static function uploadFromTypedArray(texture:Texture, renderSession:GLRenderSession, data:ArrayBufferView, miplevel:UInt = 0):Void {
 		if (data == null)
 			return;
+
 		var gl = renderSession.gl;
 
 		var width = texture.__width >> miplevel;

--- a/src/openfl/display3D/textures/CubeTexture.hx
+++ b/src/openfl/display3D/textures/CubeTexture.hx
@@ -37,8 +37,6 @@ final class CubeTexture extends TextureBase {
 	}
 
 	public function uploadFromBitmapData(source:BitmapData, side:UInt, miplevel:UInt = 0, generateMipmap:Bool = false):Void {
-		if (source == null)
-			return;
 		GLCubeTexture.uploadFromBitmapData(this, __context.__renderSession, source, side, miplevel, generateMipmap);
 	}
 
@@ -47,8 +45,6 @@ final class CubeTexture extends TextureBase {
 	}
 
 	public function uploadFromTypedArray(data:ArrayBufferView, side:UInt, miplevel:UInt = 0):Void {
-		if (data == null)
-			return;
 		GLCubeTexture.uploadFromTypedArray(this, __context.__renderSession, data, side, miplevel);
 	}
 

--- a/src/openfl/display3D/textures/Texture.hx
+++ b/src/openfl/display3D/textures/Texture.hx
@@ -10,8 +10,6 @@ import openfl.utils.ByteArray;
 
 @:access(openfl.display3D.Context3D)
 final class Texture extends TextureBase {
-	private static var __lowMemoryMode:Bool = false;
-
 	private function new(context:Context3D, width:Int, height:Int, format:Context3DTextureFormat, optimizeForRenderToTexture:Bool, streamingLevels:Int) {
 		super(context);
 


### PR DESCRIPTION
After the change to upload stage3D textures from canvas/image-driven BitmapData, this broke the mipmap upload for GLCubeTexture on Chrome/Windows (Mac or non-Chromium based browsers on Windows aren't affected afaik). The result are distorted textures.
GLCubeTexture is affected only, because for GLTexture, in case the source is smaller than the given size (e.g. mipmaps), there is code to shrink the source by drawing it to an additional canvas first.

Ideally we would also avoid that, for example by using WebGL2 API (where you can specifiy the size of the canvas/image that you really want to upload), but for now I'll simply use the same shrinking via an additional canvas.