### PR TITLE
Some upload cleanup

### DIFF
--- a/src/openfl/_internal/stage3D/opengl/GLCubeTexture.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLCubeTexture.hx
@@ -34,16 +34,19 @@ class GLCubeTexture {
 
 		var hasTexture = false;
 
-		reader.readTextures(function(side, level, gpuFormat, width, height, blockLength, bytes) {
+		reader.readTextures(function(side, level, gpuFormat, size, unused, blockLength, bytes) {
 			var format = GLTextureBase.__compressedTextureFormats.toTextureFormat(alpha, gpuFormat);
 			if (format == 0)
+				return;
+
+			if (size == 0)
 				return;
 
 			hasTexture = true;
 			cubeTexture.__format = format;
 			cubeTexture.__internalFormat = format;
 
-			gl.compressedTexImage2D(__sideToTarget(side), level, cubeTexture.__internalFormat, width, height, 0, bytes, 0, blockLength);
+			gl.compressedTexImage2D(__sideToTarget(side), level, cubeTexture.__internalFormat, size, size, 0, bytes, 0, blockLength);
 			GLUtils.checkGLError(gl);
 
 			cubeTexture.__uploadedSides |= 1 << side;

--- a/src/openfl/_internal/stage3D/opengl/GLCubeTexture.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLCubeTexture.hx
@@ -89,6 +89,9 @@ class GLCubeTexture {
 
 	public static function uploadFromByteArray(cubeTexture:CubeTexture, renderSession:GLRenderSession, data:ByteArray, byteArrayOffset:UInt, side:UInt,
 			miplevel:UInt = 0):Void {
+		if (data == null)
+			return;
+
 		#if js
 		if (byteArrayOffset == 0) {
 			uploadFromTypedArray(cubeTexture, renderSession, @:privateAccess (data : ByteArrayData).b, side, miplevel);
@@ -101,9 +104,6 @@ class GLCubeTexture {
 
 	public static function uploadFromTypedArray(cubeTexture:CubeTexture, renderSession:GLRenderSession, data:ArrayBufferView, side:UInt,
 			miplevel:UInt = 0):Void {
-		if (data == null)
-			return;
-
 		var gl = renderSession.gl;
 
 		var size = cubeTexture.__size >> miplevel;

--- a/src/openfl/_internal/stage3D/opengl/GLCubeTexture.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLCubeTexture.hx
@@ -34,7 +34,7 @@ class GLCubeTexture {
 
 		var hasTexture = false;
 
-		reader.readTextures(function(side, level, gpuFormat, size, unused, blockLength, bytes) {
+		reader.readTextures(function(side, level, gpuFormat, size, _, blockLength, bytes) {
 			var format = GLTextureBase.__compressedTextureFormats.toTextureFormat(alpha, gpuFormat);
 			if (format == 0)
 				return;

--- a/src/openfl/_internal/stage3D/opengl/GLCubeTexture.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLCubeTexture.hx
@@ -72,6 +72,7 @@ class GLCubeTexture {
 			return;
 
 		var size = cubeTexture.__size >> miplevel;
+
 		if (size == 0)
 			return;
 
@@ -106,6 +107,7 @@ class GLCubeTexture {
 		var gl = renderSession.gl;
 
 		var size = cubeTexture.__size >> miplevel;
+
 		if (size == 0)
 			return;
 
@@ -122,7 +124,7 @@ class GLCubeTexture {
 
 		cubeTexture.__uploadedSides |= 1 << side;
 
-		// var memUsage = (__size * __size) * 4;
+		// var memUsage = (size * size) * 4;
 		// __trackMemoryUsage (memUsage);
 	}
 

--- a/src/openfl/_internal/stage3D/opengl/GLIndexBuffer3D.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLIndexBuffer3D.hx
@@ -41,15 +41,15 @@ class GLIndexBuffer3D {
 
 	public static function uploadFromByteArray(indexBuffer:IndexBuffer3D, renderSession:GLRenderSession, data:ByteArray, byteArrayOffset:Int, startOffset:Int,
 			count:Int):Void {
+		if (data == null)
+			return;
+
 		var offset = byteArrayOffset + startOffset * 2;
 
 		uploadFromTypedArray(indexBuffer, renderSession, new Int16Array(data, offset, count));
 	}
 
 	public static function uploadFromTypedArray(indexBuffer:IndexBuffer3D, renderSession:GLRenderSession, data:ArrayBufferView):Void {
-		if (data == null)
-			return;
-
 		var gl = renderSession.gl;
 
 		gl.bindBuffer(GL.ELEMENT_ARRAY_BUFFER, indexBuffer.__id);

--- a/src/openfl/_internal/stage3D/opengl/GLIndexBuffer3D.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLIndexBuffer3D.hx
@@ -34,8 +34,8 @@ class GLIndexBuffer3D {
 			gl.deleteBuffer(indexBuffer.__id);
 		}
 
-		// __context.__statsDecrement(Context3D.Context3DTelemetry.COUNT_INDEX_BUFFER);
-		// __context.__statsSubtract(Context3D.Context3DTelemetry.MEM_INDEX_BUFFER, __memoryUsage);
+		// __context.__statsDecrement (Context3D.Context3DTelemetry.COUNT_INDEX_BUFFER);
+		// __context.__statsSubtract (Context3D.Context3DTelemetry.MEM_INDEX_BUFFER, __memoryUsage);
 		// __memoryUsage = 0;
 	}
 
@@ -43,12 +43,13 @@ class GLIndexBuffer3D {
 			count:Int):Void {
 		var offset = byteArrayOffset + startOffset * 2;
 
-		uploadFromTypedArray(indexBuffer, renderSession, new Int16Array(data.toArrayBuffer(), offset, count));
+		uploadFromTypedArray(indexBuffer, renderSession, new Int16Array(data, offset, count));
 	}
 
 	public static function uploadFromTypedArray(indexBuffer:IndexBuffer3D, renderSession:GLRenderSession, data:ArrayBufferView):Void {
 		if (data == null)
 			return;
+
 		var gl = renderSession.gl;
 
 		gl.bindBuffer(GL.ELEMENT_ARRAY_BUFFER, indexBuffer.__id);
@@ -66,15 +67,16 @@ class GLIndexBuffer3D {
 	}
 
 	public static function uploadFromVector(indexBuffer:IndexBuffer3D, renderSession:GLRenderSession, data:Vector<UInt>, startOffset:Int, count:Int):Void {
-		// TODO: Optimize more
-
 		if (data == null)
 			return;
+
 		var gl = renderSession.gl;
 
-		var length = startOffset + count;
-		var existingInt16Array = indexBuffer.__tempInt16Array;
+		// TODO: Optimize more
 
+		var length = startOffset + count;
+
+		var existingInt16Array = indexBuffer.__tempInt16Array;
 		if (indexBuffer.__tempInt16Array == null || indexBuffer.__tempInt16Array.length < count) {
 			indexBuffer.__tempInt16Array = new Int16Array(count);
 

--- a/src/openfl/_internal/stage3D/opengl/GLRectangleTexture.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLRectangleTexture.hx
@@ -26,8 +26,11 @@ class GLRectangleTexture {
 		if (source == null)
 			return;
 
+		var width = rectangleTexture.__width;
+		var height = rectangleTexture.__height;
+
 		var image = rectangleTexture.__getImage(source);
-		GLTextureBase.uploadFromImage(renderSession.gl, rectangleTexture, image, 0, rectangleTexture.__width, rectangleTexture.__height);
+		GLTextureBase.uploadFromImage(renderSession.gl, rectangleTexture, image, 0, width, height);
 	}
 
 	public static function uploadFromByteArray(rectangleTexture:RectangleTexture, renderSession:GLRenderSession, data:ByteArray, byteArrayOffset:UInt):Void {
@@ -47,17 +50,20 @@ class GLRectangleTexture {
 
 		var gl = renderSession.gl;
 
+		var width = rectangleTexture.__width;
+		var height = rectangleTexture.__height;
+
 		gl.bindTexture(rectangleTexture.__textureTarget, rectangleTexture.__textureData.glTexture);
 		GLUtils.checkGLError(gl);
 
-		gl.texImage2D(rectangleTexture.__textureTarget, 0, rectangleTexture.__internalFormat, rectangleTexture.__width, rectangleTexture.__height, 0,
-			rectangleTexture.__format, GL.UNSIGNED_BYTE, data);
+		gl.texImage2D(rectangleTexture.__textureTarget, 0, rectangleTexture.__internalFormat, width, height, 0, rectangleTexture.__format, GL.UNSIGNED_BYTE,
+			data);
 		GLUtils.checkGLError(gl);
 
 		gl.bindTexture(rectangleTexture.__textureTarget, null);
 		GLUtils.checkGLError(gl);
 
-		// var memUsage = (__width * __height) * 4;
+		// var memUsage = (width * height) * 4;
 		// __trackMemoryUsage (memUsage);
 	}
 

--- a/src/openfl/_internal/stage3D/opengl/GLRectangleTexture.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLRectangleTexture.hx
@@ -34,6 +34,9 @@ class GLRectangleTexture {
 	}
 
 	public static function uploadFromByteArray(rectangleTexture:RectangleTexture, renderSession:GLRenderSession, data:ByteArray, byteArrayOffset:UInt):Void {
+		if (data == null)
+			return;
+
 		#if js
 		if (byteArrayOffset == 0) {
 			uploadFromTypedArray(rectangleTexture, renderSession, @:privateAccess (data : ByteArrayData).b);
@@ -45,9 +48,6 @@ class GLRectangleTexture {
 	}
 
 	public static function uploadFromTypedArray(rectangleTexture:RectangleTexture, renderSession:GLRenderSession, data:ArrayBufferView):Void {
-		if (data == null)
-			return;
-
 		var gl = renderSession.gl;
 
 		var width = rectangleTexture.__width;

--- a/src/openfl/_internal/stage3D/opengl/GLRectangleTexture.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLRectangleTexture.hx
@@ -27,10 +27,6 @@ class GLRectangleTexture {
 			return;
 
 		var image = rectangleTexture.__getImage(source);
-
-		if (image == null)
-			return;
-
 		GLTextureBase.uploadFromImage(renderSession.gl, rectangleTexture, image, 0, rectangleTexture.__width, rectangleTexture.__height);
 	}
 
@@ -46,11 +42,8 @@ class GLRectangleTexture {
 	}
 
 	public static function uploadFromTypedArray(rectangleTexture:RectangleTexture, renderSession:GLRenderSession, data:ArrayBufferView):Void {
-		// if (__format != Context3DTextureFormat.BGRA) {
-		//
-		// throw new IllegalOperationError ();
-		//
-		// }
+		if (data == null)
+			return;
 
 		var gl = renderSession.gl;
 

--- a/src/openfl/_internal/stage3D/opengl/GLRectangleTexture.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLRectangleTexture.hx
@@ -16,8 +16,6 @@ import openfl.utils.ByteArray;
 @:access(openfl.display3D.Context3D)
 class GLRectangleTexture {
 	public static function create(rectangleTexture:RectangleTexture, renderSession:GLRenderSession):Void {
-		var gl = renderSession.gl;
-
 		rectangleTexture.__textureTarget = GL.TEXTURE_2D;
 		uploadFromTypedArray(rectangleTexture, renderSession, null);
 	}

--- a/src/openfl/_internal/stage3D/opengl/GLTexture.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLTexture.hx
@@ -96,6 +96,9 @@ class GLTexture {
 	}
 
 	public static function uploadFromByteArray(texture:Texture, renderSession:GLRenderSession, data:ByteArray, byteArrayOffset:UInt, miplevel:UInt = 0):Void {
+		if (data == null)
+			return;
+
 		#if js
 		if (byteArrayOffset == 0) {
 			uploadFromTypedArray(texture, renderSession, @:privateAccess (data : ByteArrayData).b, miplevel);
@@ -107,9 +110,6 @@ class GLTexture {
 	}
 
 	public static function uploadFromTypedArray(texture:Texture, renderSession:GLRenderSession, data:ArrayBufferView, miplevel:UInt = 0):Void {
-		if (data == null)
-			return;
-
 		var gl = renderSession.gl;
 
 		var width = texture.__width >> miplevel;

--- a/src/openfl/_internal/stage3D/opengl/GLTexture.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLTexture.hx
@@ -17,18 +17,7 @@ import openfl.utils.ByteArray;
 @:access(openfl.display3D.Context3D)
 class GLTexture {
 	public static function create(texture:Texture, renderSession:GLRenderSession):Void {
-		var gl = renderSession.gl;
-
 		texture.__textureTarget = GL.TEXTURE_2D;
-
-		gl.bindTexture(texture.__textureTarget, texture.__textureData.glTexture);
-		GLUtils.checkGLError(gl);
-
-		gl.texImage2D(texture.__textureTarget, 0, texture.__internalFormat, texture.__width, texture.__height, 0, texture.__format, GL.UNSIGNED_BYTE, null);
-		GLUtils.checkGLError(gl);
-
-		gl.bindTexture(texture.__textureTarget, null);
-
 		uploadFromTypedArray(texture, renderSession, null);
 	}
 

--- a/src/openfl/_internal/stage3D/opengl/GLTexture.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLTexture.hx
@@ -32,7 +32,7 @@ class GLTexture {
 
 		var hasTexture = false;
 
-		reader.readTextures(function(unused, level, gpuFormat, width, height, blockLength, bytes) {
+		reader.readTextures(function(_, level, gpuFormat, width, height, blockLength, bytes) {
 			var format = GLTextureBase.__compressedTextureFormats.toTextureFormat(alpha, gpuFormat);
 			if (format == 0)
 				return;

--- a/src/openfl/_internal/stage3D/opengl/GLTexture.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLTexture.hx
@@ -32,10 +32,18 @@ class GLTexture {
 
 		var hasTexture = false;
 
-		reader.readTextures(function(target, level, gpuFormat, width, height, blockLength, bytes) {
+		reader.readTextures(function(unused, level, gpuFormat, width, height, blockLength, bytes) {
 			var format = GLTextureBase.__compressedTextureFormats.toTextureFormat(alpha, gpuFormat);
 			if (format == 0)
 				return;
+
+			if (width == 0 && height == 0)
+				return;
+
+			if (width == 0)
+				width = 1;
+			if (height == 0)
+				height = 1;
 
 			hasTexture = true;
 			texture.__format = format;

--- a/src/openfl/_internal/stage3D/opengl/GLTextureBase.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLTextureBase.hx
@@ -192,6 +192,9 @@ class GLTextureBase {
 	}
 
 	public static function uploadFromImage(gl:GL, texture:TextureBase, image:Image, miplevel:Int, width:Int, height:Int, uploadTarget:Int = -1) {
+		if (image == null)
+			return;
+
 		if (uploadTarget == -1) uploadTarget = texture.__textureTarget;
 
 		gl.bindTexture(texture.__textureTarget, texture.__textureData.glTexture);

--- a/src/openfl/_internal/stage3D/opengl/GLVertexBuffer3D.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLVertexBuffer3D.hx
@@ -41,6 +41,9 @@ class GLVertexBuffer3D {
 
 	public static function uploadFromByteArray(vertexBuffer:VertexBuffer3D, renderSession:GLRenderSession, data:ByteArray, byteArrayOffset:Int, startVertex:Int,
 			numVertices:Int):Void {
+		if (data == null)
+			return;
+
 		var offset = byteArrayOffset + startVertex * vertexBuffer.__stride;
 		var length = numVertices * vertexBuffer.__vertexSize;
 
@@ -48,9 +51,6 @@ class GLVertexBuffer3D {
 	}
 
 	public static function uploadFromTypedArray(vertexBuffer:VertexBuffer3D, renderSession:GLRenderSession, data:ArrayBufferView):Void {
-		if (data == null)
-			return;
-
 		var gl = renderSession.gl;
 
 		gl.bindBuffer(GL.ARRAY_BUFFER, vertexBuffer.__id);

--- a/src/openfl/_internal/stage3D/opengl/GLVertexBuffer3D.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLVertexBuffer3D.hx
@@ -15,15 +15,15 @@ class GLVertexBuffer3D {
 	public static function create(vertexBuffer:VertexBuffer3D, renderSession:GLRenderSession, bufferUsage:Context3DBufferUsage) {
 		var gl = renderSession.gl;
 
+		vertexBuffer.__stride = vertexBuffer.__vertexSize * 4;
+
 		vertexBuffer.__id = gl.createBuffer();
 		GLUtils.checkGLError(gl);
-
-		vertexBuffer.__stride = vertexBuffer.__vertexSize * 4;
-		// __memoryUsage = 0;
 
 		vertexBuffer.__usage = (bufferUsage == Context3DBufferUsage.DYNAMIC_DRAW) ? GL.DYNAMIC_DRAW : GL.STATIC_DRAW;
 
 		// __context.__statsIncrement (Context3D.Context3DTelemetry.COUNT_VERTEX_BUFFER);
+		// __memoryUsage = 0;
 	}
 
 	public static function dispose(vertexBuffer:VertexBuffer3D, renderSession:GLRenderSession):Void {
@@ -50,6 +50,7 @@ class GLVertexBuffer3D {
 	public static function uploadFromTypedArray(vertexBuffer:VertexBuffer3D, renderSession:GLRenderSession, data:ArrayBufferView):Void {
 		if (data == null)
 			return;
+
 		var gl = renderSession.gl;
 
 		gl.bindBuffer(GL.ARRAY_BUFFER, vertexBuffer.__id);
@@ -70,6 +71,7 @@ class GLVertexBuffer3D {
 			numVertices:Int):Void {
 		if (data == null)
 			return;
+
 		var gl = renderSession.gl;
 
 		// TODO: Optimize more
@@ -79,7 +81,6 @@ class GLVertexBuffer3D {
 		var length = start + count;
 
 		var existingFloat32Array = vertexBuffer.__tempFloat32Array;
-
 		if (vertexBuffer.__tempFloat32Array == null || vertexBuffer.__tempFloat32Array.length < count) {
 			vertexBuffer.__tempFloat32Array = new Float32Array(count);
 

--- a/src/openfl/display3D/IndexBuffer3D.hx
+++ b/src/openfl/display3D/IndexBuffer3D.hx
@@ -3,12 +3,12 @@ package openfl.display3D;
 import lime.graphics.opengl.GLBuffer;
 import lime.utils.ArrayBufferView;
 import lime.utils.Int16Array;
+import openfl.Vector;
 import openfl._internal.stage3D.opengl.GLIndexBuffer3D;
 import openfl.utils.ByteArray;
-import openfl.Vector;
 
 @:access(openfl.display3D.Context3D)
-final class IndexBuffer3D {
+class IndexBuffer3D {
 	private var __context:Context3D;
 	private var __elementType:Int;
 	private var __id:GLBuffer;

--- a/src/openfl/display3D/VertexBuffer3D.hx
+++ b/src/openfl/display3D/VertexBuffer3D.hx
@@ -10,11 +10,10 @@ import openfl.utils.ByteArray;
 @:access(openfl.display3D.Context3D)
 class VertexBuffer3D {
 	private var __context:Context3D;
-	private var __data:Vector<Float>;
+	private var __stride:Int;
 	private var __id:GLBuffer;
 	private var __memoryUsage:Int;
 	private var __numVertices:Int;
-	private var __stride:Int;
 	private var __tempFloat32Array:Float32Array;
 	private var __usage:Int;
 	private var __vertexSize:Int;

--- a/src/openfl/display3D/textures/RectangleTexture.hx
+++ b/src/openfl/display3D/textures/RectangleTexture.hx
@@ -8,7 +8,7 @@ import openfl.utils.ByteArray;
 
 @:access(openfl.display3D.Context3D)
 final class RectangleTexture extends TextureBase {
-	private function new(context:Context3D, width:Int, height:Int, format:String, optimizeForRenderToTexture:Bool) {
+	private function new(context:Context3D, width:Int, height:Int, format:Context3DTextureFormat, optimizeForRenderToTexture:Bool) {
 		super(context);
 
 		__width = width;


### PR DESCRIPTION
This makes the code for stage3d texture and vertex/index buffer upload consistent, except that for CubeTexture there is no null buffer upload by the constructor (which we might want to add, but so far it isn't needed). And for RectangleTexture there is no dimension check.

This PR also has a fix for uploading compressed rectangular mipmaps (e.g. 1024x512). The problem is that such mipmaps have the following final dimensions and buffers:

0 = 1024x512
...
n-2 = 2x1
n-1 = 1x1

The n-1 dimension is interesting, as the code by bitshift produces 1x0, while the buffer contains data for 1x1. That's why we apply the same dimension check (and correction) as we have for non-compressed mipmaps.

While cleaning this up I was wondering about the fake data upload for compressed textures again. As we also don't upload anything special in case other texture uploads fail (e.g. fail by dimension check), I'm not sure if we really want to upload fake data when the texture file doesn't contain proper compressed data... Anyhow, I haven't touched it for now