### PR TITLE
Avoid all errors when WebGL context cannot be created

### DIFF
--- a/src/openfl/_internal/renderer/opengl/GLRenderer.hx
+++ b/src/openfl/_internal/renderer/opengl/GLRenderer.hx
@@ -32,28 +32,28 @@ class GLRenderer {
 		width = stage.stageWidth;
 		height = stage.stageHeight;
 
-		if (Graphics.maxTextureWidth == null) {
-			Graphics.maxTextureWidth = Graphics.maxTextureHeight = gl.getParameter(GL.MAX_TEXTURE_SIZE);
-		}
-
 		matrix = new Matrix4();
 
-		renderSession = new GLRenderSession(this, gl);
-		renderSession.pixelRatio = stage.window.scale;
-
-		if (stage.window != null) {
-			if (stage.stage3Ds[0].context3D == null) {
-				stage.stage3Ds[0].__createContext(stage, renderSession);
+		if (gl != null) {
+			if (Graphics.maxTextureWidth == null) {
+				Graphics.maxTextureWidth = Graphics.maxTextureHeight = gl.getParameter(GL.MAX_TEXTURE_SIZE);
 			}
-
-			var width = Math.ceil(stage.window.width * stage.window.scale);
-			var height = Math.ceil(stage.window.height * stage.window.scale);
-
-			resize(width, height);
+			renderSession = new GLRenderSession(this, gl);
 		}
+
+		if (stage.stage3Ds[0].context3D == null) {
+			stage.stage3Ds[0].__createContext(stage, renderSession);
+		}
+
+		var width = Std.int(stage.window.width * stage.window.scale);
+		var height = Std.int(stage.window.height * stage.window.scale);
+
+		resize(width, height);
 	}
 
 	public function clear():Void {
+		if (gl == null) return;
+
 		if (stage.__transparent) {
 			gl.clearColor(0, 0, 0, 0);
 		} else {
@@ -94,7 +94,11 @@ class GLRenderer {
 	}
 
 	public function render():Void {
+		if (gl == null) return;
+
 		gl.viewport(offsetX, offsetY, displayWidth, displayHeight);
+
+		renderSession.pixelRatio = stage.window.scale;
 
 		renderSession.allowSmoothing = (stage.quality != LOW);
 		renderSession.forceSmoothing = #if always_smooth_on_upscale (displayMatrix.a != 1 || displayMatrix.d != 1); #else false; #end

--- a/src/openfl/_internal/stage3D/opengl/GLContext3D.hx
+++ b/src/openfl/_internal/stage3D/opengl/GLContext3D.hx
@@ -895,11 +895,6 @@ class GLContext3D {
 	}
 
 	public static function __updateBackbufferViewport(context:Context3D):Void {
-		if (!Stage3D.__active) {
-			Stage3D.__active = true;
-			context.__renderSession.renderer.clear();
-		}
-
 		if (context.__renderToTexture == null && context.backBufferWidth > 0 && context.backBufferHeight > 0) {
 			__setViewport(context.__renderSession.gl, Std.int(context.__stage3D.x), Std.int(context.__stage3D.y), context.backBufferWidth,
 				context.backBufferHeight);

--- a/src/openfl/display/Stage.hx
+++ b/src/openfl/display/Stage.hx
@@ -476,7 +476,6 @@ class Stage extends DisplayObjectContainer {
 			if (!Stage3D.__active) {
 				__renderer.clear();
 			}
-
 			__renderer.render();
 		}
 
@@ -1112,9 +1111,6 @@ class Stage extends DisplayObjectContainer {
 
 		if (__contentsScaleFactor != window.scale && __renderer != null) {
 			__contentsScaleFactor = window.scale;
-
-			@:privateAccess (__renderer.renderSession).pixelRatio = window.scale;
-
 			__forceRenderDirty();
 		}
 
@@ -1130,8 +1126,6 @@ class Stage extends DisplayObjectContainer {
 	private function __setLogicalSize(width:Int, height:Int):Void {
 		__logicalWidth = width;
 		__logicalHeight = height;
-
-		__resize();
 	}
 
 	private function __startDrag(sprite:Sprite, lockCenter:Bool, bounds:Rectangle):Void {

--- a/src/openfl/display/Stage3D.hx
+++ b/src/openfl/display/Stage3D.hx
@@ -48,8 +48,13 @@ class Stage3D extends EventDispatcher {
 
 	private function __createContext(stage:Stage, renderSession:GLRenderSession):Void {
 		__stage = stage;
-		context3D = new Context3D(this, renderSession);
-		__dispatchCreate();
+		if (renderSession != null) {
+			context3D = new Context3D(this, renderSession);
+			__active = true;
+			__dispatchCreate();
+		} else {
+			__dispatchError();
+		}
 	}
 
 	private function __dispatchError():Void {
@@ -73,14 +78,9 @@ class Stage3D extends EventDispatcher {
 		}
 
 		if (context3D != null) {
-			__resetContext3DStates();
+			context3D.__updateBackbufferViewport();
 			GLStage3D.render(this, renderSession);
 		}
-	}
-
-	private function __resetContext3DStates():Void {
-		// TODO: Better viewport fix
-		context3D.__updateBackbufferViewport();
 	}
 
 	private function __loseContext():Void {
@@ -89,6 +89,7 @@ class Stage3D extends EventDispatcher {
 		}
 
 		context3D = null;
+		__active = false;
 	}
 
 	private function get_x():Float {


### PR DESCRIPTION
- adding back __dispatchError()
- avoid GL errors when the stage is ticked without a valid context
- avoid calling the render session before creation