### PR TITLE
Bring back class map

### DIFF
--- a/src/openfl/utils/Dictionary.hx
+++ b/src/openfl/utils/Dictionary.hx
@@ -57,16 +57,16 @@ abstract Dictionary<K, V>(IMap<K, V>) {
 		return new EnumValueMap<K, V>();
 	}
 
+	@:to static function toClassMap<K:Class<Dynamic>, V>(t:IMap<K, V>, weakKeys:Bool):ClassMap<K, V> {
+		return new ClassMap<K, V>();
+	}
+
 	@:to static function toObjectMap<K:{}, V>(t:IMap<K, V>, weakKeys:Bool):ObjectMap<K, V> {
 		return new ObjectMap<K, V>();
 	}
 
 	@:to static function toUtilsObjectMap<K:Object, V>(t:IMap<K, V>, weakKeys:Bool):UtilsObjectMap<K, V> {
 		return new UtilsObjectMap<K, V>();
-	}
-
-	@:to static function toClassMap<K:Class<Dynamic>, V>(t:IMap<K, V>, weakKeys:Bool):ClassMap<K, V> {
-		return new ClassMap<K, V>();
 	}
 
 	@:from static inline function fromStringMap<V>(map:StringMap<V>):Dictionary<String, V> {
@@ -81,15 +81,15 @@ abstract Dictionary<K, V>(IMap<K, V>) {
 		return cast map;
 	}
 
+	@:from static inline function fromClassMap<K:Class<Dynamic>, V>(map:ClassMap<K, V>):Dictionary<K, V> {
+		return cast map;
+	}
+
 	@:from static inline function fromObjectMap<K:{}, V>(map:ObjectMap<K, V>):Dictionary<K, V> {
 		return cast map;
 	}
 
 	@:from static inline function fromUtilsObjectMap<K:Object, V>(map:UtilsObjectMap<K, V>):Dictionary<K, V> {
-		return cast map;
-	}
-
-	@:from static inline function fromClassMap<K:Class<Dynamic>, V>(map:ClassMap<K, V>):Dictionary<K, V> {
 		return cast map;
 	}
 }


### PR DESCRIPTION
At the moment, at least with Haxe 4.1.5, openfl.Dictionary always compiles to UtilsObjectMap for Class<T>. This is because UtilsObjectMap uses openfl.Object as key type and this is an abstract over Dynamic. That way at the moment Class<T> matches openfl.Object and so it generates UtilsObjectMap instead of ClassMap. By swapping the order I give Class<T> precedence over openfl.Object, so it generates ClassMap again, which I believe is correct.

~~I also added fromEnumValueMap as openfl.Dictionary already has toEnumValueMap and this was the only missing pair.~~
Removed fromEnumValueMap again as Haxe Map also doesn't have it: https://github.com/HaxeFoundation/haxe/blob/4.1.4/std/haxe/ds/Map.hx