### PR TITLE
add failIfMajorPerformanceCaveat option

### DIFF
--- a/src/lime/app/Config.hx
+++ b/src/lime/app/Config.hx
@@ -110,4 +110,5 @@ typedef WindowConfig = {
 	@:optional var width:Int;
 	@:optional var x:Int;
 	@:optional var y:Int;
+	@:optional var failIfMajorPerformanceCaveat:Bool;
 }

--- a/src/lime/graphics/Renderer.hx
+++ b/src/lime/graphics/Renderer.hx
@@ -36,7 +36,8 @@ class Renderer {
 				depth: Reflect.hasField(window.config, "depthBuffer") ? window.config.depthBuffer : true,
 				premultipliedAlpha: true,
 				stencil: Reflect.hasField(window.config, "stencilBuffer") ? window.config.stencilBuffer : false,
-				preserveDrawingBuffer: false
+				preserveDrawingBuffer: false,
+				failIfMajorPerformanceCaveat: Reflect.hasField(window.config, "failIfMajorPerformanceCaveat") ? window.config.failIfMajorPerformanceCaveat : false
 			};
 
 			for (name in ["webgl2", "webgl", "experimental-webgl"]) {


### PR DESCRIPTION
See https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.2.1 for description:
If the value is true, context creation will fail if the implementation determines that the performance of the created WebGL context would be dramatically lower than that of a native application making equivalent OpenGL calls. This could happen for a number of reasons, including:

* An implementation might switch to a software rasterizer if the user's GPU driver is known to be unstable.
* An implementation might require reading back the framebuffer from GPU memory to system memory before compositing it with the rest of the page, significantly reducing performance.

Applications that don't require high performance should leave this parameter at its default value of false. Applications that require high performance may set this parameter to true, and if context creation fails then the application may prefer to use a fallback rendering path such as a 2D canvas context. Alternatively the application can retry WebGL context creation with this parameter set to false, with the knowledge that a reduced-fidelity rendering mode should be used to improve performance.