### PR TITLE
Remove SKIP major performance caveat test

### DIFF
--- a/src/lime/app/Config.hx
+++ b/src/lime/app/Config.hx
@@ -86,14 +86,8 @@ typedef Config = {
 	@:optional var windows:Array<WindowConfig>;
 }
 
-enum MajorPerformanceCaveatTest {
-	FAIL_IF;
-	ALLOW_IF;
-	SKIP;
-}
-
 typedef WindowConfig = {
-	@:optional var majorPerformanceCaveatTest:MajorPerformanceCaveatTest;
+	@:optional var failIfMajorPerformanceCaveat:Bool;
 	@:optional var allowHighDPI:Bool;
 	@:optional var alwaysOnTop:Bool;
 	@:optional var antialiasing:Int;

--- a/src/lime/graphics/Renderer.hx
+++ b/src/lime/graphics/Renderer.hx
@@ -59,7 +59,7 @@ class Renderer {
 			window.config.failIfMajorPerformanceCaveat : false;
 
 		createGLContext(true);
-		failIfMajorPerformanceCaveat = context == null; // true if hardware context fails
+		hasMajorPerformanceCaveat = context == null; // true if hardware context fails
 
 		if (context == null && !failIfMajorPerformanceCaveat) {
 			createGLContext(false);

--- a/src/lime/graphics/Renderer.hx
+++ b/src/lime/graphics/Renderer.hx
@@ -61,7 +61,7 @@ class Renderer {
 		createGLContext(true);
 		hasMajorPerformanceCaveat = context == null; // true if hardware context fails
 
-		if (context == null && !failIfMajorPerformanceCaveat) {
+		if (hasMajorPerformanceCaveat && !failIfMajorPerformanceCaveat) {
 			createGLContext(false);
 		}
 	}

--- a/src/lime/graphics/Renderer.hx
+++ b/src/lime/graphics/Renderer.hx
@@ -55,15 +55,13 @@ class Renderer {
 			return;
 		}
 
-		var test:MajorPerformanceCaveatTest = Reflect.hasField(window.config, "majorPerformanceCaveatTest") ?
-			window.config.majorPerformanceCaveatTest : SKIP;
+		var failIfMajorPerformanceCaveat = Reflect.hasField(window.config, "failIfMajorPerformanceCaveat") ?
+			window.config.failIfMajorPerformanceCaveat : false;
 
-		if (test != SKIP) {
-			createGLContext(true);
-			hasMajorPerformanceCaveat = context == null; // true if hardware context fails
-		}
+		createGLContext(true);
+		failIfMajorPerformanceCaveat = context == null; // true if hardware context fails
 
-		if (context == null && test != FAIL_IF) {
+		if (context == null && !failIfMajorPerformanceCaveat) {
 			createGLContext(false);
 		}
 	}


### PR DESCRIPTION
We introduced a SKIP major performance caveat option as a precautionary measure in case something would have gone wrong on our live servers we could have disable the test. As nothing went wrong, this option is obsolete. We want always to test for major performance caveat and react if there is one.